### PR TITLE
Fix UTF-8 decoding errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Handle UTF-8 decoding issues without a panic, fixing [#1](https://github.com/georust/kml/issues/1)
+
 ## [v0.3.0](https://github.com/georust/kml/releases/tag/v0.3.0)
 
 - Cleaned up method names (i.e. "parse*" to "read*")


### PR DESCRIPTION
Closes #1. Currently any issues with UTF-8 decoding cause a panic, so this adds a fallback to `from_utf8_lossy` instead of calling `expect`