### PR TITLE
build(deps): update quick-xml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["geo", "geospatial", "kml"]
 exclude = [".github/*"]
 
 [dependencies]
-quick-xml = "0.20"
+quick-xml = "0.22"
 num-traits = "0.2"
 thiserror = "1.0"
 geo-types = { version = ">=0.6, <0.8", optional = true }


### PR DESCRIPTION
Bumps the version of `quick-xml`. Based on the [changelog](https://github.com/tafia/quick-xml/blob/master/Changelog.md) the breaking changes shouldn't impact the project