### PR TITLE
fix: compilation failure without zip feature

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,6 +30,7 @@ pub enum Error {
     InvalidListItemType(String),
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
+    #[cfg(feature = "zip")]
     #[error("ZIP error: {0}")]
     ZipError(#[from] zip::result::ZipError),
     #[error("Invalid units: {0}")]


### PR DESCRIPTION
Closes #21.
This adds conditional compilation to the `ZipError` error variant so that it is only compiled with the _zip_ feature.