### PR TITLE
Serialization: Changed write order for extrude, tessellate, altitudeModeGroup

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -451,7 +451,7 @@ where
                     .map(Coord::to_string)
                     .collect::<Vec<String>>()
                     .join("\n"),
-            )
+            )?
         }
         Ok(())
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -439,6 +439,9 @@ where
     }
 
     fn write_geom_props(&mut self, props: GeomProps<T>) -> Result<(), Error> {
+        self.write_text_element(b"extrude", if props.extrude { "1" } else { "0" })?;
+        self.write_text_element(b"tessellate", if props.tessellate { "1" } else { "0" })?;
+        self.write_text_element(b"altitudeMode", &props.altitude_mode.to_string())?;
         if !props.coords.is_empty() {
             self.write_text_element(
                 b"coordinates",
@@ -448,11 +451,8 @@ where
                     .map(Coord::to_string)
                     .collect::<Vec<String>>()
                     .join("\n"),
-            )?;
+            )
         }
-        self.write_text_element(b"extrude", if props.extrude { "1" } else { "0" })?;
-        self.write_text_element(b"tessellate", if props.tessellate { "1" } else { "0" })?;
-        self.write_text_element(b"altitudeMode", &props.altitude_mode.to_string())
     }
 
     fn write_container(

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -451,8 +451,8 @@ where
             )?;
         }
         self.write_text_element(b"extrude", if props.extrude { "1" } else { "0" })?;
-        self.write_text_element(b"tessellate", if props.tessellate { "1" } else { "0" });
-        self.write_text_element(b"altitudeMode", &props.altitude_mode.to_string())?
+        self.write_text_element(b"tessellate", if props.tessellate { "1" } else { "0" })?;
+        self.write_text_element(b"altitudeMode", &props.altitude_mode.to_string())
     }
 
     fn write_container(

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -237,11 +237,11 @@ where
         if let Some(description) = &placemark.description {
             self.write_text_element(b"description", description)?;
         }
-        for c in placemark.children.iter() {
-            self.write_element(c)?;
-        }
         if let Some(geometry) = &placemark.geometry {
             self.write_geometry(geometry)?;
+        }
+        for c in placemark.children.iter() {
+            self.write_element(c)?;
         }
         Ok(self
             .writer

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -453,6 +453,7 @@ where
                     .join("\n"),
             )
         }
+        Ok(())
     }
 
     fn write_container(

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -451,8 +451,8 @@ where
             )?;
         }
         self.write_text_element(b"extrude", if props.extrude { "1" } else { "0" })?;
-        self.write_text_element(b"tessellate", if props.tessellate { "1" } else { "0" })
-        self.write_text_element(b"altitudeMode", &props.altitude_mode.to_string())?;
+        self.write_text_element(b"tessellate", if props.tessellate { "1" } else { "0" });
+        self.write_text_element(b"altitudeMode", &props.altitude_mode.to_string())?
     }
 
     fn write_container(

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -513,12 +513,12 @@ mod tests {
     #[test]
     fn test_write_point() {
         let kml = Kml::Point(Point {
-            altitude_mode: types::AltitudeMode::RelativeToGround,
             coord: Coord {
                 x: 1.,
                 y: 1.,
                 z: Some(1.),
             },
+            altitude_mode: types::AltitudeMode::RelativeToGround,
             ..Default::default()
         });
     assert_eq!("<Point><extrude>0</extrude><altitudeMode>relativeToGround</altitudeMode><coordinates>1,1,1</coordinates></Point>", kml.to_string());
@@ -575,7 +575,6 @@ mod tests {
     fn test_write_polygon() {
         let kml = Kml::Polygon(Polygon {
             outer: LinearRing {
-                tessellate: true,
                 coords: vec![
                     Coord {
                         x: -1.,
@@ -598,6 +597,7 @@ mod tests {
                         z: Some(0.),
                     },
                 ],
+                tessellate: true,
                 ..Default::default()
             },
             inner: vec![],

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -237,11 +237,11 @@ where
         if let Some(description) = &placemark.description {
             self.write_text_element(b"description", description)?;
         }
-        if let Some(geometry) = &placemark.geometry {
-            self.write_geometry(geometry)?;
-        }
         for c in placemark.children.iter() {
             self.write_element(c)?;
+        }
+        if let Some(geometry) = &placemark.geometry {
+            self.write_geometry(geometry)?;
         }
         Ok(self
             .writer


### PR DESCRIPTION
Changed write order on serialization for `extrude`, `tessellate` for `write_point()` and `extrude`, `tessellate`, `altitudeMode` for `write_geom_props` so that the result validates against http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd