### PR TITLE
Run tests without default features in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        features: ["--no-default-features", "--all-features"]
+        features: ["", "--no-default-features", "--all-features"]
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+    types: [opened, synchronized]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:
@@ -32,8 +38,8 @@ jobs:
           command: build
           args: --verbose
 
-  test:
-    name: Test
+  bench:
+    name: Bench
     runs-on: ubuntu-latest
 
     steps:
@@ -53,11 +59,29 @@ jobs:
           command: bench
           args: --no-run
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features: ["--no-default-features", "--all-features"]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose
+          args: ${{ matrix.features }} --verbose
 
   clippy:
     name: Clippy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,12 +39,14 @@
 //! let kml_data = kml_reader.read().unwrap();
 //!
 //! // Read KMZ files with the `zip` feature or default features enabled
+//! # #[cfg(feature = "zip")] {
 //! let kmz_path = Path::new(env!("CARGO_MANIFEST_DIR"))
 //!     .join("tests")
 //!     .join("fixtures")
 //!     .join("polygon.kmz");
 //! let mut kmz_reader = KmlReader::<_, f64>::from_kmz_path(kmz_path).unwrap();
 //! let kmz_data = kmz_reader.read().unwrap();
+//! # }
 //! ```
 //!
 //! ### Writing
@@ -64,6 +66,7 @@
 //! ### Conversion
 //!
 //! ```
+//! # #[cfg(feature = "geo-types")] {
 //! use geo_types::{self, GeometryCollection};
 //! use kml::{quick_collection, Kml, types::Point};
 //!
@@ -88,6 +91,7 @@
 //!
 //! // Use the quick_collection helper to convert Kml to a geo_types::GeometryCollection
 //! let geom_coll: GeometryCollection<f64> = quick_collection(kml_folder).unwrap();
+//! # }
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/src/types/kml.rs
+++ b/src/types/kml.rs
@@ -10,7 +10,7 @@ use crate::types::{
 
 /// Enum for representing the KML version being parsed
 ///
-/// According to http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#7 namespace for 2.3
+/// According to <http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#7> namespace for 2.3
 /// is unchanged since it should be backwards-compatible
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -6,7 +6,7 @@ use crate::types::coord::{Coord, CoordType};
 /// `kml:Point`, [10.2](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#446) in the KML
 /// specification
 ///
-/// Coord is required as of https://docs.opengeospatial.org/ts/14-068r2/14-068r2.html#atc-114
+/// Coord is required as of <https://docs.opengeospatial.org/ts/14-068r2/14-068r2.html#atc-114>
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct Point<T: CoordType = f64> {
     pub coord: Coord<T>,


### PR DESCRIPTION
Adds running `cargo test` with `--no-default-features` to the CI test step, and splits out running `cargo bench` into its own job since it's not important there. This should prevent running into any issues like #21.

I had to update some of the doctests with `#[cfg]` but I'm commenting that out so that it doesn't show in the final documentation output.

Also includes two unrelated changes to reduce the amount of duplication in running CI (currently running on branch and PR for every PR made from a branch on this repo) and to make two links clickable that I ran into while testing `cargo doc` locally. These seemed pretty small and easiest to just incorporate here

Feedback is welcome! This should be a pretty minor fix as long as CI passes