### PR TITLE
Update edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 documentation = "https://docs.rs/kml/"
 repository = "https://github.com/georust/kml"
 license = "MIT/Apache-2.0"
-edition = "2018"
+edition = "2021"
 keywords = ["geo", "geospatial", "kml"]
 exclude = [".github/*"]
 


### PR DESCRIPTION
Running `cargo fix --edition` didn't produce any actual changes, but it seems worth updating the edition in `Cargo.toml` to reflect that in case a future edition does require changes