### PR TITLE
Add kml:Link, kml:Icon

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,6 +28,10 @@ pub enum Error {
     InvalidColorMode(String),
     #[error("Invalid list item type: {0}")]
     InvalidListItemType(String),
+    #[error("Invalid refresh mode: {0}")]
+    InvalidRefreshMode(String),
+    #[error("Invalid view refresh mode: {0}")]
+    InvalidViewRefreshMode(String),
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
     #[cfg(feature = "zip")]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -16,9 +16,9 @@ use crate::errors::Error;
 use crate::types::geom_props::GeomProps;
 use crate::types::{
     self, coords_from_str, BalloonStyle, ColorMode, Coord, CoordType, Element, Geometry, Icon,
-    IconStyle, Kml, KmlDocument, KmlVersion, LabelStyle, LineString, LineStyle, LinearRing,
-    LinkTypeIcon, LinkTypeLink, ListStyle, Location, MultiGeometry, Orientation, Pair, Placemark,
-    Point, PolyStyle, Polygon, RefreshMode, Scale, Style, StyleMap, Units, Vec2, ViewRefreshMode,
+    IconStyle, Kml, KmlDocument, KmlVersion, LabelStyle, LineString, LineStyle, LinearRing, Link,
+    LinkTypeIcon, ListStyle, Location, MultiGeometry, Orientation, Pair, Placemark, Point,
+    PolyStyle, Polygon, RefreshMode, Scale, Style, StyleMap, Units, Vec2, ViewRefreshMode,
 };
 
 /// Main struct for reading KML documents
@@ -158,9 +158,7 @@ where
                             elements.push(Kml::BalloonStyle(self.read_balloon_style(attrs)?))
                         }
                         b"IconStyle" => elements.push(Kml::IconStyle(self.read_icon_style(attrs)?)),
-                        b"Link" => {
-                            elements.push(Kml::LinkTypeLink(self.read_link_type_link(attrs)?))
-                        }
+                        b"Link" => elements.push(Kml::Link(self.read_link(attrs)?)),
                         b"Icon" => {
                             elements.push(Kml::LinkTypeIcon(self.read_link_type_icon(attrs)?))
                         }
@@ -652,11 +650,8 @@ where
         Ok(icon)
     }
 
-    fn read_link_type_link(
-        &mut self,
-        attrs: HashMap<String, String>,
-    ) -> Result<LinkTypeLink, Error> {
-        let mut link = LinkTypeLink {
+    fn read_link(&mut self, attrs: HashMap<String, String>) -> Result<Link, Error> {
+        let mut link = Link {
             attrs,
             ..Default::default()
         };
@@ -1032,7 +1027,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_link_type_link() {
+    fn test_read_link() {
         let kml_str = r#"<Link id="Some ID">
             <href>/path/to/local/resource</href>
             <refreshMode>onChange</refreshMode>
@@ -1049,7 +1044,7 @@ mod tests {
         let l: Kml = kml_str.parse().unwrap();
         assert_eq!(
             l,
-            Kml::LinkTypeLink(LinkTypeLink {
+            Kml::Link(Link {
                 href: Some("/path/to/local/resource".to_string()),
                 refresh_mode: Some(types::RefreshMode::OnChange),
                 view_refresh_mode: Some(types::ViewRefreshMode::OnStop),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -616,22 +616,11 @@ where
                 Event::Start(ref mut e) => match e.local_name() {
                     b"href" => icon.href = Some(self.read_str()?),
                     b"refreshMode" => {
-                        icon.refresh_mode = match self.read_str()?.as_str() {
-                            "onChange" => Some(RefreshMode::OnChange),
-                            "onInterval" => Some(RefreshMode::OnInterval),
-                            "onExpire" => Some(RefreshMode::OnExpire),
-                            _ => None,
-                        }
+                        icon.refresh_mode = Some(RefreshMode::from_str(&self.read_str()?)?);
                     }
                     b"refreshInterval" => icon.refresh_interval = self.read_float()?,
                     b"viewRefreshMode" => {
-                        icon.view_refresh_mode = match self.read_str()?.as_str() {
-                            "never" => Some(ViewRefreshMode::Never),
-                            "onRequest" => Some(ViewRefreshMode::OnRequest),
-                            "onStop" => Some(ViewRefreshMode::OnStop),
-                            "onRegion" => Some(ViewRefreshMode::OnRegion),
-                            _ => None,
-                        }
+                        icon.view_refresh_mode = Some(ViewRefreshMode::from_str(&self.read_str()?)?)
                     }
                     b"viewRefreshTime" => icon.view_refresh_time = self.read_float()?,
                     b"viewBoundScale" => icon.view_bound_scale = self.read_float()?,
@@ -661,22 +650,11 @@ where
                 Event::Start(ref mut e) => match e.local_name() {
                     b"href" => link.href = Some(self.read_str()?),
                     b"refreshMode" => {
-                        link.refresh_mode = match self.read_str()?.as_str() {
-                            "onChange" => Some(RefreshMode::OnChange),
-                            "onInterval" => Some(RefreshMode::OnInterval),
-                            "onExpire" => Some(RefreshMode::OnExpire),
-                            _ => None,
-                        }
+                        link.refresh_mode = Some(RefreshMode::from_str(&self.read_str()?)?);
                     }
                     b"refreshInterval" => link.refresh_interval = self.read_float()?,
                     b"viewRefreshMode" => {
-                        link.view_refresh_mode = match self.read_str()?.as_str() {
-                            "never" => Some(ViewRefreshMode::Never),
-                            "onRequest" => Some(ViewRefreshMode::OnRequest),
-                            "onStop" => Some(ViewRefreshMode::OnStop),
-                            "onRegion" => Some(ViewRefreshMode::OnRegion),
-                            _ => None,
-                        }
+                        link.view_refresh_mode = Some(ViewRefreshMode::from_str(&self.read_str()?)?)
                     }
                     b"viewRefreshTime" => link.view_refresh_time = self.read_float()?,
                     b"viewBoundScale" => link.view_bound_scale = self.read_float()?,

--- a/src/types/kml.rs
+++ b/src/types/kml.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::errors::Error;
 use crate::types::{
     BalloonStyle, CoordType, Element, Icon, IconStyle, LabelStyle, LineString, LineStyle,
-    LinearRing, LinkTypeIcon, LinkTypeLink, ListStyle, Location, MultiGeometry, Orientation, Pair,
+    LinearRing, Link, LinkTypeIcon, ListStyle, Location, MultiGeometry, Orientation, Pair,
     Placemark, Point, PolyStyle, Polygon, Scale, Style, StyleMap,
 };
 
@@ -83,6 +83,6 @@ pub enum Kml<T: CoordType = f64> {
     PolyStyle(PolyStyle),
     ListStyle(ListStyle),
     LinkTypeIcon(LinkTypeIcon),
-    LinkTypeLink(LinkTypeLink),
+    Link(Link),
     Element(Element),
 }

--- a/src/types/kml.rs
+++ b/src/types/kml.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 use crate::errors::Error;
 use crate::types::{
     BalloonStyle, CoordType, Element, Icon, IconStyle, LabelStyle, LineString, LineStyle,
-    LinearRing, ListStyle, Location, MultiGeometry, Orientation, Pair, Placemark, Point, PolyStyle,
-    Polygon, Scale, Style, StyleMap,
+    LinearRing, Link, ListStyle, Location, MultiGeometry, Orientation, Pair, Placemark, Point,
+    PolyStyle, Polygon, Scale, Style, StyleMap,
 };
 
 /// Enum for representing the KML version being parsed
@@ -82,5 +82,6 @@ pub enum Kml<T: CoordType = f64> {
     LineStyle(LineStyle),
     PolyStyle(PolyStyle),
     ListStyle(ListStyle),
+    Link(Link),
     Element(Element),
 }

--- a/src/types/kml.rs
+++ b/src/types/kml.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 use crate::errors::Error;
 use crate::types::{
     BalloonStyle, CoordType, Element, Icon, IconStyle, LabelStyle, LineString, LineStyle,
-    LinearRing, LinkType, ListStyle, Location, MultiGeometry, Orientation, Pair, Placemark, Point,
-    PolyStyle, Polygon, Scale, Style, StyleMap,
+    LinearRing, LinkTypeIcon, LinkTypeLink, ListStyle, Location, MultiGeometry, Orientation, Pair,
+    Placemark, Point, PolyStyle, Polygon, Scale, Style, StyleMap,
 };
 
 /// Enum for representing the KML version being parsed
@@ -82,6 +82,7 @@ pub enum Kml<T: CoordType = f64> {
     LineStyle(LineStyle),
     PolyStyle(PolyStyle),
     ListStyle(ListStyle),
-    LinkType(LinkType),
+    LinkTypeIcon(LinkTypeIcon),
+    LinkTypeLink(LinkTypeLink),
     Element(Element),
 }

--- a/src/types/kml.rs
+++ b/src/types/kml.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::errors::Error;
 use crate::types::{
     BalloonStyle, CoordType, Element, Icon, IconStyle, LabelStyle, LineString, LineStyle,
-    LinearRing, Link, ListStyle, Location, MultiGeometry, Orientation, Pair, Placemark, Point,
+    LinearRing, LinkType, ListStyle, Location, MultiGeometry, Orientation, Pair, Placemark, Point,
     PolyStyle, Polygon, Scale, Style, StyleMap,
 };
 
@@ -82,6 +82,6 @@ pub enum Kml<T: CoordType = f64> {
     LineStyle(LineStyle),
     PolyStyle(PolyStyle),
     ListStyle(ListStyle),
-    Link(Link),
+    LinkType(LinkType),
     Element(Element),
 }

--- a/src/types/link.rs
+++ b/src/types/link.rs
@@ -3,41 +3,64 @@ use std::{
     fmt::{Display, Formatter, Result},
 };
 
-/// Common model for `kml:LinkType`, [13.1](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#974) in the KML specification.
+/// `kml:Link`, [13.1](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#974) in the KML specification.
 #[derive(Clone, Debug, PartialEq)]
-pub struct LinkModel {
-    pub href: String,
+pub struct Link {
+    pub href: Option<String>,
     pub refresh_mode: Option<RefreshMode>,
     pub refresh_interval: f64,
     pub view_refresh_mode: Option<ViewRefreshMode>,
     pub view_refresh_time: f64,
     pub view_bound_scale: f64,
-    pub view_format: String,
-    pub http_query: String,
+    pub view_format: Option<String>,
+    pub http_query: Option<String>,
     pub attrs: HashMap<String, String>,
 }
 
-impl Default for LinkModel {
-    fn default() -> LinkModel {
-        LinkModel {
-            href: "".to_string(),
+impl Default for Link {
+    fn default() -> Self {
+        Self {
+            href: None,
             refresh_mode: None,
             refresh_interval: 4.0,
             view_refresh_mode: None,
             view_refresh_time: 4.0,
             view_bound_scale: 1.0,
-            view_format: "".to_string(),
-            http_query: "".to_string(),
+            view_format: None,
+            http_query: None,
             attrs: HashMap::new(),
         }
     }
 }
 
-/// `kml:Link` and `kml:Icon`, [13.1](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#974) in the KML specification.
+/// `kml:Icon`, [13.1](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#974) in the KML specification.
 #[derive(Clone, Debug, PartialEq)]
-pub enum LinkType {
-    Icon(LinkModel),
-    Link(LinkModel),
+pub struct Icon {
+    pub href: Option<String>,
+    pub refresh_mode: Option<RefreshMode>,
+    pub refresh_interval: f64,
+    pub view_refresh_mode: Option<ViewRefreshMode>,
+    pub view_refresh_time: f64,
+    pub view_bound_scale: f64,
+    pub view_format: Option<String>,
+    pub http_query: Option<String>,
+    pub attrs: HashMap<String, String>,
+}
+
+impl Default for Icon {
+    fn default() -> Self {
+        Self {
+            href: None,
+            refresh_mode: None,
+            refresh_interval: 4.0,
+            view_refresh_mode: None,
+            view_refresh_time: 4.0,
+            view_bound_scale: 1.0,
+            view_format: None,
+            http_query: None,
+            attrs: HashMap::new(),
+        }
+    }
 }
 
 /// `kml:refreshModeEnumType`, [16.21](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#1239) in the KML specification.

--- a/src/types/link.rs
+++ b/src/types/link.rs
@@ -1,7 +1,8 @@
-use std::{
-    collections::HashMap,
-    fmt::{Display, Formatter, Result},
-};
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+
+use crate::Error;
 
 /// `kml:Link`, [13.1](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#974) in the KML specification.
 #[derive(Clone, Debug, PartialEq)]
@@ -77,8 +78,21 @@ impl Default for RefreshMode {
     }
 }
 
-impl Display for RefreshMode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+impl FromStr for RefreshMode {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "onChange" => Ok(Self::OnChange),
+            "onInterval" => Ok(Self::OnInterval),
+            "onExpire" => Ok(Self::OnExpire),
+            v => Err(Error::InvalidRefreshMode(v.to_string())),
+        }
+    }
+}
+
+impl fmt::Display for RefreshMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RefreshMode::OnChange => write!(f, "onChange"),
             RefreshMode::OnInterval => write!(f, "onInterval"),
@@ -102,13 +116,68 @@ impl Default for ViewRefreshMode {
     }
 }
 
-impl Display for ViewRefreshMode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+impl FromStr for ViewRefreshMode {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "never" => Ok(Self::Never),
+            "onRequest" => Ok(Self::OnRequest),
+            "onStop" => Ok(Self::OnStop),
+            "onRegion" => Ok(Self::OnRegion),
+            v => Err(Error::InvalidViewRefreshMode(v.to_string())),
+        }
+    }
+}
+
+impl fmt::Display for ViewRefreshMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ViewRefreshMode::Never => write!(f, "never"),
             ViewRefreshMode::OnRequest => write!(f, "onRequest"),
             ViewRefreshMode::OnStop => write!(f, "onStop"),
             ViewRefreshMode::OnRegion => write!(f, "onRegion"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_refresh_mode_from_str() {
+        assert_eq!(
+            RefreshMode::OnChange,
+            RefreshMode::from_str("onChange").unwrap()
+        );
+        assert_eq!(
+            RefreshMode::OnExpire,
+            RefreshMode::from_str("onExpire").unwrap()
+        );
+        assert_eq!(
+            RefreshMode::OnInterval,
+            RefreshMode::from_str("onInterval").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_view_refresh_mode_from_str() {
+        assert_eq!(
+            ViewRefreshMode::Never,
+            ViewRefreshMode::from_str("never").unwrap()
+        );
+        assert_eq!(
+            ViewRefreshMode::OnRegion,
+            ViewRefreshMode::from_str("onRegion").unwrap()
+        );
+        assert_eq!(
+            ViewRefreshMode::OnRequest,
+            ViewRefreshMode::from_str("onRequest").unwrap()
+        );
+        assert_eq!(
+            ViewRefreshMode::OnStop,
+            ViewRefreshMode::from_str("onStop").unwrap()
+        );
     }
 }

--- a/src/types/link.rs
+++ b/src/types/link.rs
@@ -1,0 +1,96 @@
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter, Result},
+};
+
+/// `kml:Link`, [13.1](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#974) in the KML specification.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Link {
+    pub is_icon: bool,
+    pub href: String,
+    pub refresh_mode: Option<RefreshMode>,
+    pub refresh_interval: f64,
+    pub view_refresh_mode: Option<ViewRefreshMode>,
+    pub view_refresh_time: f64,
+    pub view_bound_scale: f64,
+    pub view_format: String,
+    pub http_query: String,
+    pub attrs: HashMap<String, String>,
+}
+
+impl Default for Link {
+    fn default() -> Link {
+        Link {
+            is_icon: false,
+            href: "".to_string(),
+            refresh_mode: None,
+            refresh_interval: 4.0,
+            view_refresh_mode: None,
+            view_refresh_time: 4.0,
+            view_bound_scale: 1.0,
+            view_format: "".to_string(),
+            http_query: "".to_string(),
+            attrs: HashMap::new(),
+        }
+    }
+}
+
+impl Link {
+    pub fn new(is_icon: bool, href: String) -> Self {
+        Link {
+            is_icon,
+            href,
+            ..Default::default()
+        }
+    }
+}
+
+/// `kml:refreshModeEnumType`, [16.21](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#1239) in the KML specification.
+#[derive(Clone, Debug, PartialEq)]
+pub enum RefreshMode {
+    OnChange,
+    OnInterval,
+    OnExpire,
+}
+
+impl Default for RefreshMode {
+    fn default() -> RefreshMode {
+        RefreshMode::OnChange
+    }
+}
+
+impl Display for RefreshMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            RefreshMode::OnChange => write!(f, "onChange"),
+            RefreshMode::OnInterval => write!(f, "onInterval"),
+            RefreshMode::OnExpire => write!(f, "onExpire"),
+        }
+    }
+}
+
+/// `kml:viewRefreshModeEnumType`, [16.27](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#1270) in the KML specification.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ViewRefreshMode {
+    Never,
+    OnRequest,
+    OnStop,
+    OnRegion,
+}
+
+impl Default for ViewRefreshMode {
+    fn default() -> ViewRefreshMode {
+        ViewRefreshMode::Never
+    }
+}
+
+impl Display for ViewRefreshMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            ViewRefreshMode::Never => write!(f, "never"),
+            ViewRefreshMode::OnRequest => write!(f, "onRequest"),
+            ViewRefreshMode::OnStop => write!(f, "onStop"),
+            ViewRefreshMode::OnRegion => write!(f, "onRegion"),
+        }
+    }
+}

--- a/src/types/link.rs
+++ b/src/types/link.rs
@@ -3,10 +3,9 @@ use std::{
     fmt::{Display, Formatter, Result},
 };
 
-/// `kml:Link`, [13.1](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#974) in the KML specification.
+/// Common model for `kml:LinkType`, [13.1](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#974) in the KML specification.
 #[derive(Clone, Debug, PartialEq)]
-pub struct Link {
-    pub is_icon: bool,
+pub struct LinkModel {
     pub href: String,
     pub refresh_mode: Option<RefreshMode>,
     pub refresh_interval: f64,
@@ -18,10 +17,9 @@ pub struct Link {
     pub attrs: HashMap<String, String>,
 }
 
-impl Default for Link {
-    fn default() -> Link {
-        Link {
-            is_icon: false,
+impl Default for LinkModel {
+    fn default() -> LinkModel {
+        LinkModel {
             href: "".to_string(),
             refresh_mode: None,
             refresh_interval: 4.0,
@@ -35,14 +33,11 @@ impl Default for Link {
     }
 }
 
-impl Link {
-    pub fn new(is_icon: bool, href: String) -> Self {
-        Link {
-            is_icon,
-            href,
-            ..Default::default()
-        }
-    }
+/// `kml:Link` and `kml:Icon`, [13.1](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#974) in the KML specification.
+#[derive(Clone, Debug, PartialEq)]
+pub enum LinkType {
+    Icon(LinkModel),
+    Link(LinkModel),
 }
 
 /// `kml:refreshModeEnumType`, [16.21](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#1239) in the KML specification.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -38,7 +38,7 @@ pub use geometry::Geometry;
 
 mod link;
 
-pub use link::{Link, RefreshMode, ViewRefreshMode};
+pub use link::{LinkModel, LinkType, RefreshMode, ViewRefreshMode};
 
 mod style;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -36,6 +36,10 @@ mod geometry;
 
 pub use geometry::Geometry;
 
+mod link;
+
+pub use link::{Link, RefreshMode, ViewRefreshMode};
+
 mod style;
 
 pub use style::{

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -38,7 +38,7 @@ pub use geometry::Geometry;
 
 mod link;
 
-pub use link::{Icon as LinkTypeIcon, Link as LinkTypeLink, RefreshMode, ViewRefreshMode};
+pub use link::{Icon as LinkTypeIcon, Link, RefreshMode, ViewRefreshMode};
 
 mod style;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -38,7 +38,7 @@ pub use geometry::Geometry;
 
 mod link;
 
-pub use link::{LinkModel, LinkType, RefreshMode, ViewRefreshMode};
+pub use link::{Icon as LinkTypeIcon, Link as LinkTypeLink, RefreshMode, ViewRefreshMode};
 
 mod style;
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -12,8 +12,8 @@ use crate::errors::Error;
 use crate::types::geom_props::GeomProps;
 use crate::types::{
     BalloonStyle, Coord, CoordType, Element, Geometry, Icon, IconStyle, Kml, LabelStyle,
-    LineString, LineStyle, LinearRing, LinkTypeIcon, LinkTypeLink, ListStyle, Location,
-    MultiGeometry, Orientation, Pair, Placemark, Point, PolyStyle, Polygon, Scale, Style, StyleMap,
+    LineString, LineStyle, LinearRing, Link, LinkTypeIcon, ListStyle, Location, MultiGeometry,
+    Orientation, Pair, Placemark, Point, PolyStyle, Polygon, Scale, Style, StyleMap,
 };
 
 /// Struct for managing writing KML
@@ -94,7 +94,7 @@ where
             Kml::PolyStyle(p) => self.write_poly_style(p)?,
             Kml::ListStyle(l) => self.write_list_style(l)?,
             Kml::LinkTypeIcon(i) => self.write_link_type_icon(i)?,
-            Kml::LinkTypeLink(l) => self.write_link_type_link(l)?,
+            Kml::Link(l) => self.write_link(l)?,
             Kml::Document { attrs, elements } => {
                 self.write_container(b"Document", attrs, elements)?
             }
@@ -457,7 +457,7 @@ where
             .write_event(Event::End(BytesEnd::borrowed(b"Icon")))?)
     }
 
-    fn write_link_type_link(&mut self, link: &LinkTypeLink) -> Result<(), Error> {
+    fn write_link(&mut self, link: &Link) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
             BytesStart::owned_name(b"Link".to_vec())
                 .with_attributes(self.hash_map_as_attrs(&link.attrs)),
@@ -599,11 +599,11 @@ mod tests {
     }
 
     #[test]
-    fn test_write_link_type_link() {
+    fn test_write_link() {
         let mut attrs = HashMap::new();
         attrs.insert("id".to_string(), "Some ID".to_string());
 
-        let kml: Kml<f64> = Kml::LinkTypeLink(LinkTypeLink {
+        let kml: Kml<f64> = Kml::Link(Link {
             href: Some("/path/to/local/resource".to_string()),
             refresh_mode: Some(types::RefreshMode::OnChange),
             view_refresh_mode: Some(types::ViewRefreshMode::OnStop),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -12,8 +12,8 @@ use crate::errors::Error;
 use crate::types::geom_props::GeomProps;
 use crate::types::{
     BalloonStyle, Coord, CoordType, Element, Geometry, Icon, IconStyle, Kml, LabelStyle,
-    LineString, LineStyle, LinearRing, LinkType, ListStyle, Location,
-    MultiGeometry, Orientation, Pair, Placemark, Point, PolyStyle, Polygon, Scale, Style, StyleMap,
+    LineString, LineStyle, LinearRing, LinkType, ListStyle, Location, MultiGeometry, Orientation,
+    Pair, Placemark, Point, PolyStyle, Polygon, Scale, Style, StyleMap,
 };
 
 /// Struct for managing writing KML


### PR DESCRIPTION
Attempt to add support for `kml:Link` and `kml:Icon`.

A couple of points to discuss.

### First

Since the spec's `kml:Icon` (or `kml:BasicLinkType`) is already implemented and exported by the library as `Kml::Icon`, I used an enum to model the spec's `kml:LinkType`. Its variants are `Kml::Link` and `Kml:Icon`. Both are constructed with `kml::types::LinkModel`, the common data model used by the spec's `kml:LinkType`.

If `kml:Model` was to be implemented using this PR, then it's `link` field would be of type `kml::types::LinkType` and it would need to be guarded so as not to have it be set to `kml::types::LinkType::Icon`:

```rust
pub struct Model {
    link: Option<kml::types::LinkType>,
    // ...
}

impl Default for Model {
    fn default() -> Model {
        Model { link: None }
    }
}

impl Model {
    pub fn get_link(&self) -> Option<&kml::types::LinkType> {
        self.link.as_ref()
    }

    pub fn set_link(&mut self, link_model: &kml::types::LinkModel) {
        self.link = Some(kml::types::LinkType::Link(link_model.clone()));
    }
}
```

Let me know how you feel about this approach.

Alternatively, I could use two identical structs with different names. I could expose Icon as `Kml::LinkIcon` to not have it interfere with the existing `Kml::Icon`.

What makes the most sense for an approachable, intuitive API?

### Second

I used empty strings for the optional String fields that have no default value. Let me know if you'd prefer to have them be `Option`s instead.

Closes #10.