### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/types/alias.rs
+++ b/src/types/alias.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 /// `kml:Alias`, [10.14](https://docs.ogc.org/is/12-007r2/12-007r2.html#598) in the KML specification.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Alias {
     pub target_href: Option<String>,
     pub source_href: Option<String>,

--- a/src/types/altitude_mode.rs
+++ b/src/types/altitude_mode.rs
@@ -5,7 +5,7 @@ use crate::errors::Error;
 
 /// `kml:altitudeMode`, [9.20](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#322) in the
 /// KML specification
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AltitudeMode {
     ClampToGround,
     RelativeToGround,

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -14,7 +14,7 @@ impl<T: Float + Debug> CoordType for T {}
 ///
 /// Coordinates are tuples with the third Z value for altitude being optional. Coordinate tuples are
 /// separated by any whitespace character
-#[derive(Copy, Clone, Default, Debug, PartialEq)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct Coord<T: CoordType = f64> {
     pub x: T,
     pub y: T,

--- a/src/types/kml.rs
+++ b/src/types/kml.rs
@@ -12,7 +12,7 @@ use crate::types::{
 ///
 /// According to <http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#7> namespace for 2.3
 /// is unchanged since it should be backwards-compatible
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum KmlVersion {
     Unknown,

--- a/src/types/line_string.rs
+++ b/src/types/line_string.rs
@@ -5,7 +5,7 @@ use crate::types::coord::{Coord, CoordType};
 
 /// `kml:LineString`, [10.7](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#488) in the
 /// KML specification
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct LineString<T: CoordType = f64> {
     pub coords: Vec<Coord<T>>,
     pub extrude: bool,

--- a/src/types/linear_ring.rs
+++ b/src/types/linear_ring.rs
@@ -5,7 +5,7 @@ use crate::types::coord::{Coord, CoordType};
 
 /// `kml:LinearRing`, [10.5](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#465) in the
 /// KML specification
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct LinearRing<T: CoordType = f64> {
     pub coords: Vec<Coord<T>>,
     pub extrude: bool,

--- a/src/types/link.rs
+++ b/src/types/link.rs
@@ -65,7 +65,7 @@ impl Default for Icon {
 }
 
 /// `kml:refreshModeEnumType`, [16.21](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#1239) in the KML specification.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RefreshMode {
     OnChange,
     OnInterval,
@@ -102,7 +102,7 @@ impl fmt::Display for RefreshMode {
 }
 
 /// `kml:viewRefreshModeEnumType`, [16.27](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#1270) in the KML specification.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ViewRefreshMode {
     Never,
     OnRequest,

--- a/src/types/location.rs
+++ b/src/types/location.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::types::coord::CoordType;
 
 /// `kml:Location`, [10.10](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#542) in the KML
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Location<T: CoordType = f64> {
     pub latitude: T,
     pub longitude: T,

--- a/src/types/orientation.rs
+++ b/src/types/orientation.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::types::coord::CoordType;
 
 /// `kml:Orientation`, [10.11](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#558) in the KML
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Orientation<T: CoordType = f64> {
     pub roll: T,
     pub tilt: T,

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -7,7 +7,7 @@ use crate::types::coord::{Coord, CoordType};
 /// specification
 ///
 /// Coord is required as of <https://docs.opengeospatial.org/ts/14-068r2/14-068r2.html#atc-114>
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Point<T: CoordType = f64> {
     pub coord: Coord<T>,
     pub extrude: bool,

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -6,7 +6,7 @@ use crate::types::linear_ring::LinearRing;
 
 /// `kml:Polygon`, [10.8](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#505) in the KML
 /// specification
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Polygon<T: CoordType = f64> {
     pub outer: LinearRing<T>,
     pub inner: Vec<LinearRing<T>>,

--- a/src/types/resource_map.rs
+++ b/src/types/resource_map.rs
@@ -2,7 +2,7 @@ use crate::types::Alias;
 use std::collections::HashMap;
 
 /// `kml:ResourceMap`, [10.13](https://docs.ogc.org/is/12-007r2/12-007r2.html#591) in the KML specification.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ResourceMap {
     pub aliases: Vec<Alias>,
     pub attrs: HashMap<String, String>,

--- a/src/types/scale.rs
+++ b/src/types/scale.rs
@@ -4,7 +4,7 @@ use crate::types::coord::CoordType;
 use num_traits::One;
 
 /// `kml:Scale`, [10.12](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#575) in the KML
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Scale<T: CoordType = f64> {
     pub x: T,
     pub y: T,

--- a/src/types/style.rs
+++ b/src/types/style.rs
@@ -21,7 +21,7 @@ pub struct Style {
 
 /// `kml:StyleMap`, [12.3](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#811) in the KML
 /// specification
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct StyleMap {
     pub id: String,
     pub pairs: Vec<Pair>,
@@ -29,7 +29,7 @@ pub struct StyleMap {
 
 /// `kml:Pair`, [12.4](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#819) in the KML
 /// specification
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Pair {
     pub key: String,
     pub style_url: String,
@@ -38,7 +38,7 @@ pub struct Pair {
 
 /// `kml:BalloonStyle`, [12.7](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#841) in the
 /// KML specification
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BalloonStyle {
     pub id: String,
     pub bg_color: Option<String>,
@@ -61,7 +61,7 @@ impl Default for BalloonStyle {
 
 /// `kml:colorMode`, [12.11](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#879) in the
 /// KML specification
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ColorMode {
     Default,
     Random,
@@ -129,7 +129,7 @@ impl Default for IconStyle {
 /// specification.
 ///
 /// Implements on `kml:BasicLinkType`
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Icon {
     pub href: String,
 }
@@ -178,7 +178,7 @@ impl Default for LineStyle {
 
 /// `kml:PolyStyle`, [12.16](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#927) in the
 /// KML specification.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolyStyle {
     pub id: String,
     pub color: String,
@@ -201,7 +201,7 @@ impl Default for PolyStyle {
 
 /// `kml:listItemType`, [12.18](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#955) in the
 /// KML specification.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ListItemType {
     Check,
     CheckOffOnly,
@@ -246,7 +246,7 @@ impl fmt::Display for ListItemType {
 
 /// `kml:ListStyle`, [12.17](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#940) in the
 /// KML specification.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ListStyle {
     pub id: String,
     pub bg_color: String,

--- a/src/types/vec2.rs
+++ b/src/types/vec2.rs
@@ -22,7 +22,7 @@ impl Default for Vec2 {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Units {
     Fraction,
     Pixels,


### PR DESCRIPTION
Fix new clippy warnings introduced by stable Rust moving to 1.63.0.

Changes generated by `cargo clippy --fix` after upgrading to Rust 1.63.0.