### PR TITLE
Add SchemaData, SimpleArrayData, SimpleData

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronized]
+    types: [opened, synchronize]
   push:
     branches:
       - main

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -18,8 +18,8 @@ use crate::types::{
     self, coords_from_str, Alias, BalloonStyle, ColorMode, Coord, CoordType, Element, Geometry,
     Icon, IconStyle, Kml, KmlDocument, KmlVersion, LabelStyle, LineString, LineStyle, LinearRing,
     Link, LinkTypeIcon, ListStyle, Location, MultiGeometry, Orientation, Pair, Placemark, Point,
-    PolyStyle, Polygon, RefreshMode, ResourceMap, Scale, Style, StyleMap, Units, Vec2,
-    ViewRefreshMode,
+    PolyStyle, Polygon, RefreshMode, ResourceMap, Scale, SchemaData, SimpleArrayData, SimpleData,
+    Style, StyleMap, Units, Vec2, ViewRefreshMode,
 };
 
 /// Main struct for reading KML documents
@@ -167,6 +167,15 @@ where
                             elements.push(Kml::ResourceMap(self.read_resource_map(attrs)?))
                         }
                         b"Alias" => elements.push(Kml::Alias(self.read_alias(attrs)?)),
+                        b"SchemaData" => {
+                            elements.push(Kml::SchemaData(self.read_schema_data(attrs)?))
+                        }
+                        b"SimpleArrayData" => {
+                            elements.push(Kml::SimpleArrayData(self.read_simple_array_data(attrs)?))
+                        }
+                        b"SimpleData" => {
+                            elements.push(Kml::SimpleData(self.read_simple_data(attrs)?))
+                        }
                         b"LabelStyle" => {
                             elements.push(Kml::LabelStyle(self.read_label_style(attrs)?))
                         }
@@ -737,6 +746,78 @@ where
         Ok(alias)
     }
 
+    fn read_schema_data(&mut self, attrs: HashMap<String, String>) -> Result<SchemaData, Error> {
+        let mut schema_data = SchemaData {
+            attrs,
+            ..Default::default()
+        };
+
+        loop {
+            let e = self.reader.read_event(&mut self.buf)?;
+            match e {
+                Event::Start(e) => match e.local_name() {
+                    b"SimpleData" => {
+                        let attrs = Self::read_attrs(e.attributes());
+                        if let Ok(simple_data) = self.read_simple_data(attrs) {
+                            schema_data.data.push(simple_data);
+                        }
+                    }
+                    b"SimpleArrayData" => {
+                        let attrs = Self::read_attrs(e.attributes());
+                        if let Ok(simple_array_data) = self.read_simple_array_data(attrs) {
+                            schema_data.arrays.push(simple_array_data);
+                        }
+                    }
+                    _ => {}
+                },
+                Event::End(e) => {
+                    if e.local_name() == b"SchemaData" {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(schema_data)
+    }
+
+    fn read_simple_array_data(
+        &mut self,
+        attrs: HashMap<String, String>,
+    ) -> Result<SimpleArrayData, Error> {
+        let mut simple_array_data = SimpleArrayData {
+            attrs,
+            ..Default::default()
+        };
+
+        loop {
+            let e = self.reader.read_event(&mut self.buf)?;
+            match e {
+                Event::Start(e) => {
+                    if let b"value" = e.local_name() {
+                        simple_array_data.values.push(self.read_str()?);
+                    }
+                }
+                Event::End(e) => {
+                    if e.local_name() == b"SimpleArrayData" {
+                        break;
+                    }
+                }
+                _ => break,
+            }
+        }
+
+        Ok(simple_array_data)
+    }
+
+    fn read_simple_data(&mut self, attrs: HashMap<String, String>) -> Result<SimpleData, Error> {
+        Ok(SimpleData {
+            value: self.read_str()?,
+            attrs,
+        })
+    }
+
     fn read_balloon_style(
         &mut self,
         attrs: HashMap<String, String>,
@@ -1198,6 +1279,65 @@ mod tests {
                 target_href: Some("../images/foo.jpg".to_string()),
                 source_href: Some("in-geometry-file/foo.jpg".to_string()),
                 attrs,
+            })
+        );
+    }
+
+    #[test]
+    fn test_read_schema_data() {
+        let kml_str = r###"<SchemaData schemaUrl="#TrailHeadTypeId">
+            <SimpleData name="TrailHeadName">Pi in the sky</SimpleData>
+            <SimpleData name="TrailLength">3.14159</SimpleData>
+            <SimpleArrayData name="cadence">
+                <value>86</value>
+                <value>113</value>
+                <value>113</value>
+            </SimpleArrayData>
+            <SimpleArrayData name="heartrate">
+                <value>181</value>
+            </SimpleArrayData>
+        </SchemaData>"###;
+
+        let a: Kml = kml_str.parse().unwrap();
+        assert_eq!(
+            a,
+            Kml::SchemaData(SchemaData {
+                data: vec![
+                    SimpleData {
+                        value: "Pi in the sky".to_string(),
+                        attrs: [("name".to_string(), "TrailHeadName".to_string())]
+                            .iter()
+                            .cloned()
+                            .collect()
+                    },
+                    SimpleData {
+                        value: "3.14159".to_string(),
+                        attrs: [("name".to_string(), "TrailLength".to_string())]
+                            .iter()
+                            .cloned()
+                            .collect()
+                    },
+                ],
+                arrays: vec![
+                    SimpleArrayData {
+                        values: vec!["86".to_string(), "113".to_string(), "113".to_string()],
+                        attrs: [("name".to_string(), "cadence".to_string())]
+                            .iter()
+                            .cloned()
+                            .collect()
+                    },
+                    SimpleArrayData {
+                        values: vec!["181".to_string()],
+                        attrs: [("name".to_string(), "heartrate".to_string())]
+                            .iter()
+                            .cloned()
+                            .collect()
+                    },
+                ],
+                attrs: [("schemaUrl".to_string(), "#TrailHeadTypeId".to_string())]
+                    .iter()
+                    .cloned()
+                    .collect(),
             })
         );
     }

--- a/src/types/data.rs
+++ b/src/types/data.rs
@@ -1,0 +1,23 @@
+use std::collections::HashMap;
+
+/// `kml:SchemaData`, [9.5](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#155) in the KML specification.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SchemaData {
+    pub data: Vec<SimpleData>,
+    pub arrays: Vec<SimpleArrayData>,
+    pub attrs: HashMap<String, String>,
+}
+
+/// `kml:SimpleData`, [9.6](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#167) in the KML specification.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SimpleData {
+    pub value: String,
+    pub attrs: HashMap<String, String>,
+}
+
+/// `kml:SimpleArrayData`, [9.7](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#177) in the KML specification.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SimpleArrayData {
+    pub values: Vec<String>,
+    pub attrs: HashMap<String, String>,
+}

--- a/src/types/kml.rs
+++ b/src/types/kml.rs
@@ -5,7 +5,8 @@ use crate::errors::Error;
 use crate::types::{
     Alias, BalloonStyle, CoordType, Element, Icon, IconStyle, LabelStyle, LineString, LineStyle,
     LinearRing, Link, LinkTypeIcon, ListStyle, Location, MultiGeometry, Orientation, Pair,
-    Placemark, Point, PolyStyle, Polygon, ResourceMap, Scale, Style, StyleMap,
+    Placemark, Point, PolyStyle, Polygon, ResourceMap, Scale, SchemaData, SimpleArrayData,
+    SimpleData, Style, StyleMap,
 };
 
 /// Enum for representing the KML version being parsed
@@ -86,5 +87,8 @@ pub enum Kml<T: CoordType = f64> {
     Link(Link),
     ResourceMap(ResourceMap),
     Alias(Alias),
+    SchemaData(SchemaData),
+    SimpleArrayData(SimpleArrayData),
+    SimpleData(SimpleData),
     Element(Element),
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -55,6 +55,10 @@ mod alias;
 
 pub use alias::Alias;
 
+mod data;
+
+pub use data::{SchemaData, SimpleArrayData, SimpleData};
+
 mod kml;
 
 pub use self::kml::{Kml, KmlDocument, KmlVersion};


### PR DESCRIPTION
Support `kml:SchemaData`, which depends on `kml:SimpleArrayData` and `kml:SimpleData`.

Closes #33, #34.