### PR TITLE
Add attrs to style elements, make ID optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- BREAKING: Updates `Style`, `StyleMap`, `BalloonStyle`, `IconStyle`, `Icon`, `LabelStyle`, `LineStyle`, `PolyStyle`, and `ListStyle` by adding public `attrs` property and changes type of `id` from `String` to `Option<String>` to more closely reflect the specification.
+
 ## [v0.6.0](https://github.com/georust/kml/releases/tag/v0.6.0)
 
 - Ignored deprecated code warnings for `geo_types::Coordinate` since we're supporting multiple versions of `geo-types` ([#40](https://github.com/georust/kml/pull/40))

--- a/src/types/style.rs
+++ b/src/types/style.rs
@@ -10,21 +10,23 @@ use crate::types::Vec2;
 /// specification
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct Style {
-    pub id: String,
+    pub id: Option<String>,
     pub balloon: Option<BalloonStyle>,
     pub icon: Option<IconStyle>,
     pub label: Option<LabelStyle>,
     pub line: Option<LineStyle>,
     pub poly: Option<PolyStyle>,
     pub list: Option<ListStyle>,
+    pub attrs: HashMap<String, String>,
 }
 
 /// `kml:StyleMap`, [12.3](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#811) in the KML
 /// specification
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct StyleMap {
-    pub id: String,
+    pub id: Option<String>,
     pub pairs: Vec<Pair>,
+    pub attrs: HashMap<String, String>,
 }
 
 /// `kml:Pair`, [12.4](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#819) in the KML
@@ -40,21 +42,23 @@ pub struct Pair {
 /// KML specification
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BalloonStyle {
-    pub id: String,
+    pub id: Option<String>,
     pub bg_color: Option<String>,
     pub text_color: String,
     pub text: Option<String>,
     pub display: bool,
+    pub attrs: HashMap<String, String>,
 }
 
 impl Default for BalloonStyle {
     fn default() -> BalloonStyle {
         BalloonStyle {
-            id: "".to_string(),
+            id: None,
             bg_color: None,
             text_color: "ffffffff".to_string(),
             text: None,
             display: true,
+            attrs: HashMap::new(),
         }
     }
 }
@@ -102,25 +106,27 @@ impl fmt::Display for ColorMode {
 /// KML specification
 #[derive(Clone, Debug, PartialEq)]
 pub struct IconStyle {
-    pub id: String,
+    pub id: Option<String>,
     pub scale: f64,
     pub heading: f64,
     pub hot_spot: Option<Vec2>,
     pub icon: Icon,
     pub color: String,
     pub color_mode: ColorMode,
+    pub attrs: HashMap<String, String>,
 }
 
 impl Default for IconStyle {
     fn default() -> IconStyle {
         IconStyle {
-            id: "".to_string(),
+            id: None,
             scale: 1.0,
             heading: 0.0,
             hot_spot: None,
             icon: Icon::default(),
             color: "ffffffff".to_string(),
             color_mode: ColorMode::default(),
+            attrs: HashMap::new(),
         }
     }
 }
@@ -132,25 +138,28 @@ impl Default for IconStyle {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Icon {
     pub href: String,
+    pub attrs: HashMap<String, String>,
 }
 
 /// `kml:LabelStyle`, [12.14](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#909) in the
 /// KML specification.
 #[derive(Clone, Debug, PartialEq)]
 pub struct LabelStyle {
-    pub id: String,
+    pub id: Option<String>,
     pub color: String,
     pub color_mode: ColorMode,
     pub scale: f64,
+    pub attrs: HashMap<String, String>,
 }
 
 impl Default for LabelStyle {
     fn default() -> LabelStyle {
         LabelStyle {
-            id: "".to_string(),
+            id: None,
             color: "ffffffff".to_string(),
             color_mode: ColorMode::default(),
             scale: 1.0,
+            attrs: HashMap::new(),
         }
     }
 }
@@ -159,19 +168,21 @@ impl Default for LabelStyle {
 /// KML specification.
 #[derive(Clone, Debug, PartialEq)]
 pub struct LineStyle {
-    pub id: String,
+    pub id: Option<String>,
     pub color: String,
     pub color_mode: ColorMode,
     pub width: f64,
+    pub attrs: HashMap<String, String>,
 }
 
 impl Default for LineStyle {
     fn default() -> LineStyle {
         LineStyle {
-            id: "".to_string(),
+            id: None,
             color: "ffffffff".to_string(),
             color_mode: ColorMode::default(),
             width: 1.0,
+            attrs: HashMap::new(),
         }
     }
 }
@@ -180,21 +191,23 @@ impl Default for LineStyle {
 /// KML specification.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolyStyle {
-    pub id: String,
+    pub id: Option<String>,
     pub color: String,
     pub color_mode: ColorMode,
     pub fill: bool,
     pub outline: bool,
+    pub attrs: HashMap<String, String>,
 }
 
 impl Default for PolyStyle {
     fn default() -> PolyStyle {
         PolyStyle {
-            id: "".to_string(),
+            id: None,
             color: "ffffffff".to_string(),
             color_mode: ColorMode::default(),
             fill: true,
             outline: true,
+            attrs: HashMap::new(),
         }
     }
 }
@@ -248,19 +261,21 @@ impl fmt::Display for ListItemType {
 /// KML specification.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ListStyle {
-    pub id: String,
+    pub id: Option<String>,
     pub bg_color: String,
     pub max_snippet_lines: u32,
     pub list_item_type: ListItemType,
+    pub attrs: HashMap<String, String>,
 }
 
 impl Default for ListStyle {
     fn default() -> ListStyle {
         ListStyle {
-            id: "".to_string(),
+            id: None,
             bg_color: "ffffffff".to_string(),
             max_snippet_lines: 2,
             list_item_type: ListItemType::default(),
+            attrs: HashMap::new(),
         }
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -285,8 +285,17 @@ where
     }
 
     fn write_style(&mut self, style: &Style) -> Result<(), Error> {
+        let attrs = if let Some(id) = &style.id {
+            vec![("id", id.as_ref())]
+        } else {
+            vec![]
+        };
+        let attrs: Vec<(&str, &str)> = attrs
+            .into_iter()
+            .chain(self.hash_map_as_attrs(&style.attrs))
+            .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Style".to_vec()).with_attributes(vec![("id", &*style.id)]),
+            BytesStart::owned_name(b"Style".to_vec()).with_attributes(attrs),
         ))?;
         if let Some(balloon) = &style.balloon {
             self.write_balloon_style(balloon)?;
@@ -312,9 +321,17 @@ where
     }
 
     fn write_style_map(&mut self, style_map: &StyleMap) -> Result<(), Error> {
+        let attrs = if let Some(id) = &style_map.id {
+            vec![("id", id.as_ref())]
+        } else {
+            vec![]
+        };
+        let attrs: Vec<(&str, &str)> = attrs
+            .into_iter()
+            .chain(self.hash_map_as_attrs(&style_map.attrs))
+            .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"StyleMap".to_vec())
-                .with_attributes(vec![("id", &*style_map.id)]),
+            BytesStart::owned_name(b"StyleMap".to_vec()).with_attributes(attrs),
         ))?;
         for p in style_map.pairs.iter() {
             self.write_pair(p)?;
@@ -337,9 +354,17 @@ where
     }
 
     fn write_balloon_style(&mut self, balloon_style: &BalloonStyle) -> Result<(), Error> {
+        let attrs = if let Some(id) = &balloon_style.id {
+            vec![("id", id.as_ref())]
+        } else {
+            vec![]
+        };
+        let attrs: Vec<(&str, &str)> = attrs
+            .into_iter()
+            .chain(self.hash_map_as_attrs(&balloon_style.attrs))
+            .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"BalloonStyle".to_vec())
-                .with_attributes(vec![("id", &*balloon_style.id)]),
+            BytesStart::owned_name(b"BalloonStyle".to_vec()).with_attributes(attrs),
         ))?;
         if let Some(bg_color) = &balloon_style.bg_color {
             self.write_text_element(b"bgColor", bg_color)?;
@@ -357,9 +382,17 @@ where
     }
 
     fn write_icon_style(&mut self, icon_style: &IconStyle) -> Result<(), Error> {
+        let attrs = if let Some(id) = &icon_style.id {
+            vec![("id", id.as_ref())]
+        } else {
+            vec![]
+        };
+        let attrs: Vec<(&str, &str)> = attrs
+            .into_iter()
+            .chain(self.hash_map_as_attrs(&icon_style.attrs))
+            .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"IconStyle".to_vec())
-                .with_attributes(vec![("id", &*icon_style.id)]),
+            BytesStart::owned_name(b"IconStyle".to_vec()).with_attributes(attrs),
         ))?;
         self.write_text_element(b"scale", &icon_style.scale.to_string())?;
         self.write_text_element(b"heading", &icon_style.heading.to_string())?;
@@ -393,9 +426,17 @@ where
     }
 
     fn write_label_style(&mut self, label_style: &LabelStyle) -> Result<(), Error> {
+        let attrs = if let Some(id) = &label_style.id {
+            vec![("id", id.as_ref())]
+        } else {
+            vec![]
+        };
+        let attrs: Vec<(&str, &str)> = attrs
+            .into_iter()
+            .chain(self.hash_map_as_attrs(&label_style.attrs))
+            .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"LabelStyle".to_vec())
-                .with_attributes(vec![("id", &*label_style.id)]),
+            BytesStart::owned_name(b"LabelStyle".to_vec()).with_attributes(attrs),
         ))?;
         self.write_text_element(b"color", &label_style.color)?;
         self.write_text_element(b"colorMode", &label_style.color_mode.to_string())?;
@@ -406,9 +447,17 @@ where
     }
 
     fn write_line_style(&mut self, line_style: &LineStyle) -> Result<(), Error> {
+        let attrs = if let Some(id) = &line_style.id {
+            vec![("id", id.as_ref())]
+        } else {
+            vec![]
+        };
+        let attrs: Vec<(&str, &str)> = attrs
+            .into_iter()
+            .chain(self.hash_map_as_attrs(&line_style.attrs))
+            .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"LineStyle".to_vec())
-                .with_attributes(vec![("id", &*line_style.id)]),
+            BytesStart::owned_name(b"LineStyle".to_vec()).with_attributes(attrs),
         ))?;
         self.write_text_element(b"color", &line_style.color)?;
         self.write_text_element(b"colorMode", &line_style.color_mode.to_string())?;
@@ -419,9 +468,17 @@ where
     }
 
     fn write_poly_style(&mut self, poly_style: &PolyStyle) -> Result<(), Error> {
+        let attrs = if let Some(id) = &poly_style.id {
+            vec![("id", id.as_ref())]
+        } else {
+            vec![]
+        };
+        let attrs: Vec<(&str, &str)> = attrs
+            .into_iter()
+            .chain(self.hash_map_as_attrs(&poly_style.attrs))
+            .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"PolyStyle".to_vec())
-                .with_attributes(vec![("id", &*poly_style.id)]),
+            BytesStart::owned_name(b"PolyStyle".to_vec()).with_attributes(attrs),
         ))?;
         self.write_text_element(b"color", &poly_style.color)?;
         self.write_text_element(b"colorMode", &poly_style.color_mode.to_string())?;
@@ -433,9 +490,17 @@ where
     }
 
     fn write_list_style(&mut self, list_style: &ListStyle) -> Result<(), Error> {
+        let attrs = if let Some(id) = &list_style.id {
+            vec![("id", id.as_ref())]
+        } else {
+            vec![]
+        };
+        let attrs: Vec<(&str, &str)> = attrs
+            .into_iter()
+            .chain(self.hash_map_as_attrs(&list_style.attrs))
+            .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"ListStyle".to_vec())
-                .with_attributes(vec![("id", &*list_style.id)]),
+            BytesStart::owned_name(b"ListStyle".to_vec()).with_attributes(attrs),
         ))?;
         self.write_text_element(b"bgColor", &list_style.bg_color)?;
         self.write_text_element(
@@ -962,6 +1027,20 @@ mod tests {
 -1.5,3,0
 -1.5,2,0
 -1,2,0</coordinates></LinearRing></outerBoundaryIs></Polygon>"#,
+            kml.to_string()
+        );
+    }
+
+    #[test]
+    fn test_write_style_map() {
+        let kml: Kml = Kml::StyleMap(StyleMap {
+            id: Some("id".to_string()),
+            attrs: HashMap::from([("test".to_string(), "test".to_string())]),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            r#"<StyleMap id="id" test="test"></StyleMap>"#,
             kml.to_string()
         );
     }


### PR DESCRIPTION
Closes #39. Adds `attrs` to style elements to keep in line with spec. Also makes `id` optional to more accurately reflect the spec

This will be a small breaking change to the `id` fields along with adding the public `attrs` field on several elements