### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["geo", "geospatial", "kml"]
 exclude = [".github/*"]
 
 [dependencies]
-quick-xml = "0.22"
+quick-xml = "0.28"
 num-traits = "0.2"
 thiserror = "1.0"
-geo-types = { version = ">=0.6, <0.8", optional = true }
-zip = { version = "0.5", optional = true }
+geo-types = { version = "0.7", optional = true }
+zip = { version = "0.6", optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 
 [features]
 default = ["geo-types", "zip"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".github/*"]
 quick-xml = "0.28"
 num-traits = "0.2"
 thiserror = "1.0"
-geo-types = { version = "0.7", optional = true }
+geo-types = { version = ">=0.6, <0.8", optional = true }
 zip = { version = "0.6", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[allow(clippy::derivable_impls)]
 pub mod types;
 
 pub use crate::types::{Kml, KmlDocument, KmlVersion};

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -121,11 +121,11 @@ where
     fn read_elements(&mut self) -> Result<Vec<Kml<T>>, Error> {
         let mut elements: Vec<Kml<T>> = Vec::new();
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(ref mut e) => {
                     let attrs = Self::read_attrs(e.attributes());
-                    match e.local_name() {
+                    match e.local_name().as_ref() {
                         b"kml" => elements.push(Kml::KmlDocument(self.read_kml_document()?)),
                         b"Scale" => elements.push(Kml::Scale(self.read_scale(attrs)?)),
                         b"Orientation" => {
@@ -188,7 +188,7 @@ where
                         }
                     };
                 }
-                Event::End(ref mut e) => match e.local_name() {
+                Event::End(ref mut e) => match e.local_name().as_ref() {
                     b"Folder" | b"Document" => break,
                     _ => {}
                 },
@@ -215,16 +215,16 @@ where
         let mut z = One::one();
 
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"x" => x = self.read_float()?,
                     b"y" => y = self.read_float()?,
                     b"z" => z = self.read_float()?,
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"Scale" {
+                    if e.local_name().as_ref() == b"Scale" {
                         break;
                     }
                 }
@@ -243,16 +243,16 @@ where
         let mut heading = Zero::zero();
 
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"roll" => roll = self.read_float()?,
                     b"tilt" => tilt = self.read_float()?,
                     b"heading" => heading = self.read_float()?,
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"Orientation" {
+                    if e.local_name().as_ref() == b"Orientation" {
                         break;
                     }
                 }
@@ -283,16 +283,16 @@ where
         let mut altitude = Zero::zero();
 
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"longitude" => longitude = self.read_float()?,
                     b"latitude" => latitude = self.read_float()?,
                     b"altitude" => altitude = self.read_float()?,
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"Location" {
+                    if e.local_name().as_ref() == b"Location" {
                         break;
                     }
                 }
@@ -337,9 +337,9 @@ where
         let mut tessellate = false;
 
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"outerBoundaryIs" => {
                         let mut outer_ring = self.read_boundary(b"outerBoundaryIs")?;
                         if outer_ring.is_empty() {
@@ -358,7 +358,7 @@ where
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"Polygon" {
+                    if e.local_name().as_ref() == b"Polygon" {
                         break;
                     }
                 }
@@ -381,11 +381,11 @@ where
     ) -> Result<MultiGeometry<T>, Error> {
         let mut geometries: Vec<Geometry<T>> = Vec::new();
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(ref e) => {
                     let attrs = Self::read_attrs(e.attributes());
-                    match e.local_name() {
+                    match e.local_name().as_ref() {
                         b"Point" => geometries.push(Geometry::Point(self.read_point(attrs)?)),
                         b"LineString" => {
                             geometries.push(Geometry::LineString(self.read_line_string(attrs)?))
@@ -400,7 +400,7 @@ where
                     }
                 }
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"MultiGeometry" {
+                    if e.local_name().as_ref() == b"MultiGeometry" {
                         break;
                     }
                 }
@@ -417,11 +417,11 @@ where
         let mut children: Vec<Element> = Vec::new();
 
         loop {
-            let e = self.reader.read_event(&mut self.buf)?;
+            let e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(ref e) => {
                     let attrs = Self::read_attrs(e.attributes());
-                    match e.local_name() {
+                    match e.local_name().as_ref() {
                         b"name" => name = Some(self.read_str()?),
                         b"description" => description = Some(self.read_str()?),
                         b"Point" => geometry = Some(Geometry::Point(self.read_point(attrs)?)),
@@ -444,7 +444,7 @@ where
                     }
                 }
                 Event::End(ref e) => {
-                    if e.local_name() == b"Placemark" {
+                    if e.local_name().as_ref() == b"Placemark" {
                         break;
                     }
                 }
@@ -467,11 +467,11 @@ where
             ..Default::default()
         };
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(ref mut e) => {
                     let attrs = Self::read_attrs(e.attributes());
-                    match e.local_name() {
+                    match e.local_name().as_ref() {
                         b"BalloonStyle" => style.balloon = Some(self.read_balloon_style(attrs)?),
                         b"IconStyle" => style.icon = Some(self.read_icon_style(attrs)?),
                         b"LabelStyle" => style.label = Some(self.read_label_style(attrs)?),
@@ -482,7 +482,7 @@ where
                     }
                 }
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"Style" {
+                    if e.local_name().as_ref() == b"Style" {
                         break;
                     }
                 }
@@ -499,16 +499,16 @@ where
             ..Default::default()
         };
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(ref mut e) => {
-                    if e.local_name() == b"Pair" {
+                    if e.local_name().as_ref() == b"Pair" {
                         let pair_attrs = Self::read_attrs(e.attributes());
                         style_map.pairs.push(self.read_pair(pair_attrs)?);
                     }
                 }
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"StyleMap" {
+                    if e.local_name().as_ref() == b"StyleMap" {
                         break;
                     }
                 }
@@ -525,15 +525,15 @@ where
         };
 
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"key" => pair.key = self.read_str()?,
                     b"styleUrl" => pair.style_url = self.read_str()?,
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"Pair" {
+                    if e.local_name().as_ref() == b"Pair" {
                         break;
                     }
                 }
@@ -550,11 +550,11 @@ where
             ..Default::default()
         };
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(ref mut e) => {
                     let attrs = Self::read_attrs(e.attributes());
-                    match e.local_name() {
+                    match e.local_name().as_ref() {
                         b"scale" => icon_style.scale = self.read_float()?,
                         b"heading" => icon_style.heading = self.read_float()?,
                         b"hot_spot" => {
@@ -590,7 +590,7 @@ where
                     }
                 }
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"IconStyle" {
+                    if e.local_name().as_ref() == b"IconStyle" {
                         break;
                     }
                 }
@@ -603,15 +603,15 @@ where
     fn read_basic_link_type_icon(&mut self, attrs: HashMap<String, String>) -> Result<Icon, Error> {
         let mut href = String::new();
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(ref mut e) => {
-                    if e.local_name() == b"href" {
+                    if e.local_name().as_ref() == b"href" {
                         href = self.read_str()?;
                     }
                 }
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"Icon" {
+                    if e.local_name().as_ref() == b"Icon" {
                         break;
                     }
                 }
@@ -630,9 +630,9 @@ where
             ..Default::default()
         };
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"href" => icon.href = Some(self.read_str()?),
                     b"refreshMode" => {
                         icon.refresh_mode = Some(RefreshMode::from_str(&self.read_str()?)?);
@@ -648,7 +648,7 @@ where
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"Icon" {
+                    if e.local_name().as_ref() == b"Icon" {
                         break;
                     }
                 }
@@ -664,9 +664,9 @@ where
             ..Default::default()
         };
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"href" => link.href = Some(self.read_str()?),
                     b"refreshMode" => {
                         link.refresh_mode = Some(RefreshMode::from_str(&self.read_str()?)?);
@@ -682,7 +682,7 @@ where
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"Link" {
+                    if e.local_name().as_ref() == b"Link" {
                         break;
                     }
                 }
@@ -701,10 +701,10 @@ where
         let mut aliases = Vec::new();
 
         loop {
-            let e = self.reader.read_event(&mut self.buf)?;
+            let e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(e) => {
-                    if e.local_name() == b"Alias" {
+                    if e.local_name().as_ref() == b"Alias" {
                         let attrs = Self::read_attrs(e.attributes());
                         if let Ok(alias) = self.read_alias(attrs) {
                             aliases.push(alias);
@@ -712,7 +712,7 @@ where
                     }
                 }
                 Event::End(e) => {
-                    if e.local_name() == b"ResourceMap" {
+                    if e.local_name().as_ref() == b"ResourceMap" {
                         break;
                     }
                 }
@@ -732,15 +732,15 @@ where
         };
 
         loop {
-            let e = self.reader.read_event(&mut self.buf)?;
+            let e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(e) => match e.local_name() {
+                Event::Start(e) => match e.local_name().as_ref() {
                     b"targetHref" => alias.target_href = Some(self.read_str()?),
                     b"sourceHref" => alias.source_href = Some(self.read_str()?),
                     _ => {}
                 },
                 Event::End(e) => {
-                    if e.local_name() == b"Alias" {
+                    if e.local_name().as_ref() == b"Alias" {
                         break;
                     }
                 }
@@ -758,9 +758,9 @@ where
         };
 
         loop {
-            let e = self.reader.read_event(&mut self.buf)?;
+            let e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(e) => match e.local_name() {
+                Event::Start(e) => match e.local_name().as_ref() {
                     b"SimpleData" => {
                         let attrs = Self::read_attrs(e.attributes());
                         if let Ok(simple_data) = self.read_simple_data(attrs) {
@@ -776,7 +776,7 @@ where
                     _ => {}
                 },
                 Event::End(e) => {
-                    if e.local_name() == b"SchemaData" {
+                    if e.local_name().as_ref() == b"SchemaData" {
                         break;
                     }
                 }
@@ -802,15 +802,15 @@ where
         }
 
         loop {
-            let e = self.reader.read_event(&mut self.buf)?;
+            let e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(e) => {
-                    if let b"value" = e.local_name() {
+                    if let b"value" = e.local_name().as_ref() {
                         simple_array_data.values.push(self.read_str()?);
                     }
                 }
                 Event::End(e) => {
-                    if e.local_name() == b"SimpleArrayData" {
+                    if e.local_name().as_ref() == b"SimpleArrayData" {
                         break;
                     }
                 }
@@ -847,9 +847,9 @@ where
             ..Default::default()
         };
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"bgColor" => balloon_style.bg_color = Some(self.read_str()?),
                     b"textColor" => balloon_style.text_color = self.read_str()?,
                     b"text" => balloon_style.text = Some(self.read_str()?),
@@ -857,7 +857,7 @@ where
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"BalloonStyle" {
+                    if e.local_name().as_ref() == b"BalloonStyle" {
                         break;
                     }
                 }
@@ -877,9 +877,9 @@ where
             ..Default::default()
         };
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"color" => label_style.color = self.read_str()?,
                     b"colorMode" => {
                         label_style.color_mode = self.read_str()?.parse::<ColorMode>()?;
@@ -888,7 +888,7 @@ where
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"LabelStyle" {
+                    if e.local_name().as_ref() == b"LabelStyle" {
                         break;
                     }
                 }
@@ -905,9 +905,9 @@ where
             ..Default::default()
         };
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"color" => line_style.color = self.read_str()?,
                     b"colorMode" => {
                         line_style.color_mode = self.read_str()?.parse::<ColorMode>()?;
@@ -916,7 +916,7 @@ where
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"LineStyle" {
+                    if e.local_name().as_ref() == b"LineStyle" {
                         break;
                     }
                 }
@@ -933,9 +933,9 @@ where
             ..Default::default()
         };
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"bgColor" => list_style.bg_color = self.read_str()?,
                     b"maxSnippetLines" => {
                         let line_str = self.read_str()?;
@@ -946,7 +946,7 @@ where
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"ListStyle" {
+                    if e.local_name().as_ref() == b"ListStyle" {
                         break;
                     }
                 }
@@ -963,9 +963,9 @@ where
             ..Default::default()
         };
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"color" => poly_style.color = self.read_str()?,
                     b"colorMode" => {
                         poly_style.color_mode = self.read_str()?.parse::<ColorMode>()?;
@@ -981,7 +981,7 @@ where
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == b"PolyStyle" {
+                    if e.local_name().as_ref() == b"PolyStyle" {
                         break;
                     }
                 }
@@ -998,10 +998,10 @@ where
     ) -> Result<Element, Error> {
         let mut element = Element::default();
         let tag = start.local_name();
-        element.name = String::from_utf8_lossy(tag).to_string();
+        element.name = String::from_utf8_lossy(tag.into_inner()).to_string();
         element.attrs = attrs;
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(e) => {
                     let start = e.to_owned();
@@ -1012,8 +1012,9 @@ where
                 }
                 Event::Text(ref mut e) => {
                     element.content = Some(
-                        e.unescape_and_decode(&self.reader)
-                            .unwrap_or_else(|_| String::from_utf8_lossy(e.escaped()).to_string()),
+                        e.unescape()
+                            .map(|s| s.to_string())
+                            .unwrap_or_else(|_| e.escape_ascii().to_string()),
                     )
                 }
                 Event::End(ref mut e) => {
@@ -1030,16 +1031,16 @@ where
     fn read_boundary(&mut self, end_tag: &[u8]) -> Result<Vec<LinearRing<T>>, Error> {
         let mut boundary: Vec<LinearRing<T>> = Vec::new();
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 Event::Start(ref mut e) => {
                     let attrs = Self::read_attrs(e.attributes());
-                    if e.local_name() == b"LinearRing" {
+                    if e.local_name().as_ref() == b"LinearRing" {
                         boundary.push(self.read_linear_ring(attrs)?);
                     }
                 }
                 Event::End(ref mut e) => {
-                    if e.local_name() == end_tag {
+                    if e.local_name().as_ref() == end_tag {
                         break;
                     }
                 }
@@ -1056,9 +1057,9 @@ where
         let mut tessellate = false;
 
         loop {
-            let mut e = self.reader.read_event(&mut self.buf)?;
+            let mut e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                Event::Start(ref mut e) => match e.local_name() {
+                Event::Start(ref mut e) => match e.local_name().as_ref() {
                     b"coordinates" => {
                         coords = coords_from_str(&self.read_str()?)?;
                     }
@@ -1070,7 +1071,7 @@ where
                     _ => {}
                 },
                 Event::End(ref mut e) => {
-                    if e.local_name() == end_tag {
+                    if e.local_name().as_ref() == end_tag {
                         break;
                     }
                 }
@@ -1099,11 +1100,15 @@ where
     }
 
     fn read_str(&mut self) -> Result<String, Error> {
-        let e = self.reader.read_event(&mut self.buf)?;
+        let e = self.reader.read_event_into(&mut self.buf)?;
         match e {
-            Event::Text(e) | Event::CData(e) => Ok(e
-                .unescape_and_decode(&self.reader)
-                .unwrap_or_else(|_| String::from_utf8_lossy(e.escaped()).to_string())),
+            Event::Text(e) => Ok(e
+                .unescape()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|_| e.escape_ascii().to_string())),
+            Event::CData(e) => {
+                Ok(String::from_utf8(e.to_vec()).unwrap_or_else(|_| e.escape_ascii().to_string()))
+            }
             Event::End(_) => Ok("".to_string()),
             e => Err(Error::InvalidXmlEvent(format!("{e:?}"))),
         }
@@ -1114,7 +1119,7 @@ where
             .filter_map(Result::ok)
             .map(|a| {
                 (
-                    String::from_utf8_lossy(a.key).to_string(),
+                    String::from_utf8_lossy(a.key.into_inner()).to_string(),
                     String::from_utf8_lossy(&a.value).to_string(),
                 )
             })

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -74,7 +74,7 @@ where
 
     fn write_kml(&mut self, k: &Kml<T>) -> Result<(), Error> {
         match k {
-            Kml::KmlDocument(d) => self.write_container(b"kml", &d.attrs, &d.elements)?,
+            Kml::KmlDocument(d) => self.write_container("kml", &d.attrs, &d.elements)?,
             Kml::Scale(s) => self.write_scale(s)?,
             Kml::Orientation(o) => self.write_orientation(o)?,
             Kml::Point(p) => self.write_point(p)?,
@@ -102,9 +102,9 @@ where
             Kml::SimpleArrayData(s) => self.write_simple_array_data(s)?,
             Kml::SimpleData(s) => self.write_simple_data(s)?,
             Kml::Document { attrs, elements } => {
-                self.write_container(b"Document", attrs, elements)?
+                self.write_container("Document", attrs, elements)?
             }
-            Kml::Folder { attrs, elements } => self.write_container(b"Folder", attrs, elements)?,
+            Kml::Folder { attrs, elements } => self.write_container("Folder", attrs, elements)?,
             Kml::Element(e) => self.write_element(e)?,
         }
 
@@ -113,59 +113,56 @@ where
 
     fn write_scale(&mut self, scale: &Scale<T>) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Scale".to_vec())
-                .with_attributes(self.hash_map_as_attrs(&scale.attrs)),
+            BytesStart::new("Scale").with_attributes(self.hash_map_as_attrs(&scale.attrs)),
         ))?;
-        self.write_text_element(b"x", &scale.x.to_string())?;
-        self.write_text_element(b"y", &scale.y.to_string())?;
-        self.write_text_element(b"z", &scale.z.to_string())?;
+        self.write_text_element("x", &scale.x.to_string())?;
+        self.write_text_element("y", &scale.y.to_string())?;
+        self.write_text_element("z", &scale.z.to_string())?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::owned(b"Scale".to_vec())))?)
+            .write_event(Event::End(BytesEnd::new("Scale")))?)
     }
 
     fn write_orientation(&mut self, orientation: &Orientation<T>) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Orientation".to_vec())
+            BytesStart::new("Orientation")
                 .with_attributes(self.hash_map_as_attrs(&orientation.attrs)),
         ))?;
-        self.write_text_element(b"roll", &orientation.roll.to_string())?;
-        self.write_text_element(b"tilt", &orientation.tilt.to_string())?;
-        self.write_text_element(b"heading", &orientation.heading.to_string())?;
+        self.write_text_element("roll", &orientation.roll.to_string())?;
+        self.write_text_element("tilt", &orientation.tilt.to_string())?;
+        self.write_text_element("heading", &orientation.heading.to_string())?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::owned(b"Orientation".to_vec())))?)
+            .write_event(Event::End(BytesEnd::new("Orientation")))?)
     }
 
     fn write_point(&mut self, point: &Point<T>) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Point".to_vec())
-                .with_attributes(self.hash_map_as_attrs(&point.attrs)),
+            BytesStart::new("Point").with_attributes(self.hash_map_as_attrs(&point.attrs)),
         ))?;
-        self.write_text_element(b"extrude", if point.extrude { "1" } else { "0" })?;
-        self.write_text_element(b"altitudeMode", &point.altitude_mode.to_string())?;
-        self.write_text_element(b"coordinates", &point.coord.to_string())?;
+        self.write_text_element("extrude", if point.extrude { "1" } else { "0" })?;
+        self.write_text_element("altitudeMode", &point.altitude_mode.to_string())?;
+        self.write_text_element("coordinates", &point.coord.to_string())?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::owned(b"Point".to_vec())))?)
+            .write_event(Event::End(BytesEnd::new("Point")))?)
     }
 
     fn write_location(&mut self, location: &Location<T>) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Location".to_vec())
-                .with_attributes(self.hash_map_as_attrs(&location.attrs)),
+            BytesStart::new("Location").with_attributes(self.hash_map_as_attrs(&location.attrs)),
         ))?;
-        self.write_text_element(b"longitude", &location.longitude.to_string())?;
-        self.write_text_element(b"latitude", &location.latitude.to_string())?;
-        self.write_text_element(b"altitude", &location.altitude.to_string())?;
+        self.write_text_element("longitude", &location.longitude.to_string())?;
+        self.write_text_element("latitude", &location.latitude.to_string())?;
+        self.write_text_element("altitude", &location.altitude.to_string())?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::owned(b"Location".to_vec())))?)
+            .write_event(Event::End(BytesEnd::new("Location")))?)
     }
 
     fn write_line_string(&mut self, line_string: &LineString<T>) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"LineString".to_vec())
+            BytesStart::new("LineString")
                 .with_attributes(self.hash_map_as_attrs(&line_string.attrs)),
         ))?;
         // TODO: Avoid clone here?
@@ -177,12 +174,12 @@ where
         })?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::owned(b"LineString".to_vec())))?)
+            .write_event(Event::End(BytesEnd::new("LineString")))?)
     }
 
     fn write_linear_ring(&mut self, linear_ring: &LinearRing<T>) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"LinearRing".to_vec())
+            BytesStart::new("LinearRing")
                 .with_attributes(self.hash_map_as_attrs(&linear_ring.attrs)),
         ))?;
         self.write_geom_props(GeomProps {
@@ -194,13 +191,12 @@ where
         })?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::owned(b"LinearRing".to_vec())))?)
+            .write_event(Event::End(BytesEnd::new("LinearRing")))?)
     }
 
     fn write_polygon(&mut self, polygon: &Polygon<T>) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Polygon".to_vec())
-                .with_attributes(self.hash_map_as_attrs(&polygon.attrs)),
+            BytesStart::new("Polygon").with_attributes(self.hash_map_as_attrs(&polygon.attrs)),
         ))?;
         self.write_geom_props(GeomProps {
             coords: Vec::new(),
@@ -209,32 +205,28 @@ where
             tessellate: polygon.tessellate,
         })?;
         self.writer
-            .write_event(Event::Start(BytesStart::owned_name(
-                b"outerBoundaryIs".to_vec(),
-            )))?;
+            .write_event(Event::Start(BytesStart::new("outerBoundaryIs")))?;
         self.write_linear_ring(&polygon.outer)?;
         self.writer
-            .write_event(Event::End(BytesEnd::borrowed(b"outerBoundaryIs")))?;
+            .write_event(Event::End(BytesEnd::new("outerBoundaryIs")))?;
 
         if !polygon.inner.is_empty() {
             self.writer
-                .write_event(Event::Start(BytesStart::owned_name(
-                    b"innerBoundaryIs".to_vec(),
-                )))?;
+                .write_event(Event::Start(BytesStart::new("innerBoundaryIs")))?;
             for b in &polygon.inner {
                 self.write_linear_ring(b)?;
             }
             self.writer
-                .write_event(Event::End(BytesEnd::borrowed(b"innerBoundaryIs")))?;
+                .write_event(Event::End(BytesEnd::new("innerBoundaryIs")))?;
         }
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"Polygon")))?)
+            .write_event(Event::End(BytesEnd::new("Polygon")))?)
     }
 
     fn write_multi_geometry(&mut self, multi_geometry: &MultiGeometry<T>) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"MultiGeometry".to_vec())
+            BytesStart::new("MultiGeometry")
                 .with_attributes(self.hash_map_as_attrs(&multi_geometry.attrs)),
         ))?;
 
@@ -243,19 +235,18 @@ where
         }
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::owned(b"MultiGeometry".to_vec())))?)
+            .write_event(Event::End(BytesEnd::new("MultiGeometry")))?)
     }
 
     fn write_placemark(&mut self, placemark: &Placemark<T>) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Placemark".to_vec())
-                .with_attributes(self.hash_map_as_attrs(&placemark.attrs)),
+            BytesStart::new("Placemark").with_attributes(self.hash_map_as_attrs(&placemark.attrs)),
         ))?;
         if let Some(name) = &placemark.name {
-            self.write_text_element(b"name", name)?;
+            self.write_text_element("name", name)?;
         }
         if let Some(description) = &placemark.description {
-            self.write_text_element(b"description", description)?;
+            self.write_text_element("description", description)?;
         }
         for c in placemark.children.iter() {
             self.write_element(c)?;
@@ -265,23 +256,22 @@ where
         }
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"Placemark")))?)
+            .write_event(Event::End(BytesEnd::new("Placemark")))?)
     }
 
     fn write_element(&mut self, e: &Element) -> Result<(), Error> {
-        let start = BytesStart::borrowed_name(e.name.as_bytes())
-            .with_attributes(self.hash_map_as_attrs(&e.attrs));
+        let start = BytesStart::new(&e.name).with_attributes(self.hash_map_as_attrs(&e.attrs));
         self.writer.write_event(Event::Start(start))?;
         if let Some(content) = &e.content {
             self.writer
-                .write_event(Event::Text(BytesText::from_plain_str(content)))?;
+                .write_event(Event::Text(BytesText::new(content)))?;
         }
         for c in e.children.iter() {
             self.write_element(c)?;
         }
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(e.name.as_bytes())))?)
+            .write_event(Event::End(BytesEnd::new(&e.name)))?)
     }
 
     fn write_style(&mut self, style: &Style) -> Result<(), Error> {
@@ -295,7 +285,7 @@ where
             .chain(self.hash_map_as_attrs(&style.attrs))
             .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Style".to_vec()).with_attributes(attrs),
+            BytesStart::new("Style").with_attributes(attrs),
         ))?;
         if let Some(balloon) = &style.balloon {
             self.write_balloon_style(balloon)?;
@@ -317,7 +307,7 @@ where
         }
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"Style")))?)
+            .write_event(Event::End(BytesEnd::new("Style")))?)
     }
 
     fn write_style_map(&mut self, style_map: &StyleMap) -> Result<(), Error> {
@@ -331,26 +321,23 @@ where
             .chain(self.hash_map_as_attrs(&style_map.attrs))
             .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"StyleMap".to_vec()).with_attributes(attrs),
+            BytesStart::new("StyleMap").with_attributes(attrs),
         ))?;
         for p in style_map.pairs.iter() {
             self.write_pair(p)?;
         }
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"StyleMap")))?)
+            .write_event(Event::End(BytesEnd::new("StyleMap")))?)
     }
 
     fn write_pair(&mut self, pair: &Pair) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Pair".to_vec())
-                .with_attributes(self.hash_map_as_attrs(&pair.attrs)),
+            BytesStart::new("Pair").with_attributes(self.hash_map_as_attrs(&pair.attrs)),
         ))?;
-        self.write_text_element(b"key", &pair.key)?;
-        self.write_text_element(b"styleUrl", &pair.style_url)?;
-        Ok(self
-            .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"Pair")))?)
+        self.write_text_element("key", &pair.key)?;
+        self.write_text_element("styleUrl", &pair.style_url)?;
+        Ok(self.writer.write_event(Event::End(BytesEnd::new("Pair")))?)
     }
 
     fn write_balloon_style(&mut self, balloon_style: &BalloonStyle) -> Result<(), Error> {
@@ -364,21 +351,21 @@ where
             .chain(self.hash_map_as_attrs(&balloon_style.attrs))
             .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"BalloonStyle".to_vec()).with_attributes(attrs),
+            BytesStart::new("BalloonStyle").with_attributes(attrs),
         ))?;
         if let Some(bg_color) = &balloon_style.bg_color {
-            self.write_text_element(b"bgColor", bg_color)?;
+            self.write_text_element("bgColor", bg_color)?;
         }
-        self.write_text_element(b"textColor", &balloon_style.text_color)?;
+        self.write_text_element("textColor", &balloon_style.text_color)?;
         if let Some(text) = &balloon_style.text {
-            self.write_text_element(b"text", text)?;
+            self.write_text_element("text", text)?;
         }
         if !balloon_style.display {
-            self.write_text_element(b"displayMode", "hide")?;
+            self.write_text_element("displayMode", "hide")?;
         }
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"BalloonStyle")))?)
+            .write_event(Event::End(BytesEnd::new("BalloonStyle")))?)
     }
 
     fn write_icon_style(&mut self, icon_style: &IconStyle) -> Result<(), Error> {
@@ -392,37 +379,36 @@ where
             .chain(self.hash_map_as_attrs(&icon_style.attrs))
             .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"IconStyle".to_vec()).with_attributes(attrs),
+            BytesStart::new("IconStyle").with_attributes(attrs),
         ))?;
-        self.write_text_element(b"scale", &icon_style.scale.to_string())?;
-        self.write_text_element(b"heading", &icon_style.heading.to_string())?;
+        self.write_text_element("scale", &icon_style.scale.to_string())?;
+        self.write_text_element("heading", &icon_style.heading.to_string())?;
         if let Some(hot_spot) = &icon_style.hot_spot {
-            self.writer.write_event(Event::Start(
-                BytesStart::owned_name(b"hotSpot".to_vec()).with_attributes(vec![
-                    ("x", &*hot_spot.x.to_string()),
-                    ("y", &*hot_spot.y.to_string()),
-                    ("xunits", &*hot_spot.xunits.to_string()),
-                    ("yunits", &*hot_spot.yunits.to_string()),
-                ]),
-            ))?;
             self.writer
-                .write_event(Event::End(BytesEnd::borrowed(b"hotSpot")))?;
+                .write_event(Event::Start(BytesStart::new("hotSpot").with_attributes(
+                    vec![
+                        ("x", &*hot_spot.x.to_string()),
+                        ("y", &*hot_spot.y.to_string()),
+                        ("xunits", &*hot_spot.xunits.to_string()),
+                        ("yunits", &*hot_spot.yunits.to_string()),
+                    ],
+                )))?;
+            self.writer
+                .write_event(Event::End(BytesEnd::new("hotSpot")))?;
         }
-        self.write_text_element(b"color", &icon_style.color)?;
-        self.write_text_element(b"colorMode", &icon_style.color_mode.to_string())?;
+        self.write_text_element("color", &icon_style.color)?;
+        self.write_text_element("colorMode", &icon_style.color_mode.to_string())?;
         self.write_icon(&icon_style.icon)?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"IconStyle")))?)
+            .write_event(Event::End(BytesEnd::new("IconStyle")))?)
     }
 
     fn write_icon(&mut self, icon: &Icon) -> Result<(), Error> {
         self.writer
-            .write_event(Event::Start(BytesStart::owned_name(b"Icon".to_vec())))?;
-        self.write_text_element(b"href", &icon.href)?;
-        Ok(self
-            .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"Icon")))?)
+            .write_event(Event::Start(BytesStart::new("Icon")))?;
+        self.write_text_element("href", &icon.href)?;
+        Ok(self.writer.write_event(Event::End(BytesEnd::new("Icon")))?)
     }
 
     fn write_label_style(&mut self, label_style: &LabelStyle) -> Result<(), Error> {
@@ -436,14 +422,14 @@ where
             .chain(self.hash_map_as_attrs(&label_style.attrs))
             .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"LabelStyle".to_vec()).with_attributes(attrs),
+            BytesStart::new("LabelStyle").with_attributes(attrs),
         ))?;
-        self.write_text_element(b"color", &label_style.color)?;
-        self.write_text_element(b"colorMode", &label_style.color_mode.to_string())?;
-        self.write_text_element(b"scale", &label_style.scale.to_string())?;
+        self.write_text_element("color", &label_style.color)?;
+        self.write_text_element("colorMode", &label_style.color_mode.to_string())?;
+        self.write_text_element("scale", &label_style.scale.to_string())?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"LabelStyle")))?)
+            .write_event(Event::End(BytesEnd::new("LabelStyle")))?)
     }
 
     fn write_line_style(&mut self, line_style: &LineStyle) -> Result<(), Error> {
@@ -457,14 +443,14 @@ where
             .chain(self.hash_map_as_attrs(&line_style.attrs))
             .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"LineStyle".to_vec()).with_attributes(attrs),
+            BytesStart::new("LineStyle").with_attributes(attrs),
         ))?;
-        self.write_text_element(b"color", &line_style.color)?;
-        self.write_text_element(b"colorMode", &line_style.color_mode.to_string())?;
-        self.write_text_element(b"width", &line_style.width.to_string())?;
+        self.write_text_element("color", &line_style.color)?;
+        self.write_text_element("colorMode", &line_style.color_mode.to_string())?;
+        self.write_text_element("width", &line_style.width.to_string())?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"LineStyle")))?)
+            .write_event(Event::End(BytesEnd::new("LineStyle")))?)
     }
 
     fn write_poly_style(&mut self, poly_style: &PolyStyle) -> Result<(), Error> {
@@ -478,15 +464,15 @@ where
             .chain(self.hash_map_as_attrs(&poly_style.attrs))
             .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"PolyStyle".to_vec()).with_attributes(attrs),
+            BytesStart::new("PolyStyle").with_attributes(attrs),
         ))?;
-        self.write_text_element(b"color", &poly_style.color)?;
-        self.write_text_element(b"colorMode", &poly_style.color_mode.to_string())?;
-        self.write_text_element(b"fill", &poly_style.fill.to_string())?;
-        self.write_text_element(b"outline", &poly_style.outline.to_string())?;
+        self.write_text_element("color", &poly_style.color)?;
+        self.write_text_element("colorMode", &poly_style.color_mode.to_string())?;
+        self.write_text_element("fill", &poly_style.fill.to_string())?;
+        self.write_text_element("outline", &poly_style.outline.to_string())?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"PolyStyle")))?)
+            .write_event(Event::End(BytesEnd::new("PolyStyle")))?)
     }
 
     fn write_list_style(&mut self, list_style: &ListStyle) -> Result<(), Error> {
@@ -500,77 +486,68 @@ where
             .chain(self.hash_map_as_attrs(&list_style.attrs))
             .collect();
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"ListStyle".to_vec()).with_attributes(attrs),
+            BytesStart::new("ListStyle").with_attributes(attrs),
         ))?;
-        self.write_text_element(b"bgColor", &list_style.bg_color)?;
-        self.write_text_element(
-            b"maxSnippetLines",
-            &list_style.max_snippet_lines.to_string(),
-        )?;
+        self.write_text_element("bgColor", &list_style.bg_color)?;
+        self.write_text_element("maxSnippetLines", &list_style.max_snippet_lines.to_string())?;
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"ListStyle")))?)
+            .write_event(Event::End(BytesEnd::new("ListStyle")))?)
     }
 
     fn write_link_type_icon(&mut self, icon: &LinkTypeIcon) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Icon".to_vec())
-                .with_attributes(self.hash_map_as_attrs(&icon.attrs)),
+            BytesStart::new("Icon").with_attributes(self.hash_map_as_attrs(&icon.attrs)),
         ))?;
         if let Some(href) = &icon.href {
-            self.write_text_element(b"href", href)?;
+            self.write_text_element("href", href)?;
         }
         if let Some(refresh_mode) = &icon.refresh_mode {
-            self.write_text_element(b"refreshMode", &refresh_mode.to_string())?;
+            self.write_text_element("refreshMode", &refresh_mode.to_string())?;
         }
-        self.write_text_element(b"refreshInterval", &icon.refresh_interval.to_string())?;
+        self.write_text_element("refreshInterval", &icon.refresh_interval.to_string())?;
         if let Some(view_refresh_mode) = &icon.view_refresh_mode {
-            self.write_text_element(b"viewRefreshMode", &view_refresh_mode.to_string())?;
+            self.write_text_element("viewRefreshMode", &view_refresh_mode.to_string())?;
         }
-        self.write_text_element(b"viewRefreshTime", &icon.view_refresh_time.to_string())?;
-        self.write_text_element(b"viewBoundScale", &icon.view_bound_scale.to_string())?;
+        self.write_text_element("viewRefreshTime", &icon.view_refresh_time.to_string())?;
+        self.write_text_element("viewBoundScale", &icon.view_bound_scale.to_string())?;
         if let Some(view_format) = &icon.view_format {
-            self.write_text_element(b"viewFormat", view_format)?;
+            self.write_text_element("viewFormat", view_format)?;
         }
         if let Some(http_query) = &icon.http_query {
-            self.write_text_element(b"httpQuery", http_query)?;
+            self.write_text_element("httpQuery", http_query)?;
         }
-        Ok(self
-            .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"Icon")))?)
+        Ok(self.writer.write_event(Event::End(BytesEnd::new("Icon")))?)
     }
 
     fn write_link(&mut self, link: &Link) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Link".to_vec())
-                .with_attributes(self.hash_map_as_attrs(&link.attrs)),
+            BytesStart::new("Link").with_attributes(self.hash_map_as_attrs(&link.attrs)),
         ))?;
         if let Some(href) = &link.href {
-            self.write_text_element(b"href", href)?;
+            self.write_text_element("href", href)?;
         }
         if let Some(refresh_mode) = &link.refresh_mode {
-            self.write_text_element(b"refreshMode", &refresh_mode.to_string())?;
+            self.write_text_element("refreshMode", &refresh_mode.to_string())?;
         }
-        self.write_text_element(b"refreshInterval", &link.refresh_interval.to_string())?;
+        self.write_text_element("refreshInterval", &link.refresh_interval.to_string())?;
         if let Some(view_refresh_mode) = &link.view_refresh_mode {
-            self.write_text_element(b"viewRefreshMode", &view_refresh_mode.to_string())?;
+            self.write_text_element("viewRefreshMode", &view_refresh_mode.to_string())?;
         }
-        self.write_text_element(b"viewRefreshTime", &link.view_refresh_time.to_string())?;
-        self.write_text_element(b"viewBoundScale", &link.view_bound_scale.to_string())?;
+        self.write_text_element("viewRefreshTime", &link.view_refresh_time.to_string())?;
+        self.write_text_element("viewBoundScale", &link.view_bound_scale.to_string())?;
         if let Some(view_format) = &link.view_format {
-            self.write_text_element(b"viewFormat", view_format)?;
+            self.write_text_element("viewFormat", view_format)?;
         }
         if let Some(http_query) = &link.http_query {
-            self.write_text_element(b"httpQuery", http_query)?;
+            self.write_text_element("httpQuery", http_query)?;
         }
-        Ok(self
-            .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"Link")))?)
+        Ok(self.writer.write_event(Event::End(BytesEnd::new("Link")))?)
     }
 
     fn write_resource_map(&mut self, resource_map: &ResourceMap) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"ResourceMap".to_vec())
+            BytesStart::new("ResourceMap")
                 .with_attributes(self.hash_map_as_attrs(&resource_map.attrs)),
         ))?;
         for alias in resource_map.aliases.iter() {
@@ -578,28 +555,27 @@ where
         }
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"ResourceMap")))?)
+            .write_event(Event::End(BytesEnd::new("ResourceMap")))?)
     }
 
     fn write_alias(&mut self, alias: &Alias) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"Alias".to_vec())
-                .with_attributes(self.hash_map_as_attrs(&alias.attrs)),
+            BytesStart::new("Alias").with_attributes(self.hash_map_as_attrs(&alias.attrs)),
         ))?;
         if let Some(href) = &alias.target_href {
-            self.write_text_element(b"targetHref", href)?;
+            self.write_text_element("targetHref", href)?;
         }
         if let Some(href) = &alias.source_href {
-            self.write_text_element(b"sourceHref", href)?;
+            self.write_text_element("sourceHref", href)?;
         }
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"Alias")))?)
+            .write_event(Event::End(BytesEnd::new("Alias")))?)
     }
 
     fn write_schema_data(&mut self, schema_data: &SchemaData) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"SchemaData".to_vec())
+            BytesStart::new("SchemaData")
                 .with_attributes(self.hash_map_as_attrs(&schema_data.attrs)),
         ))?;
 
@@ -613,7 +589,7 @@ where
 
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"SchemaData")))?)
+            .write_event(Event::End(BytesEnd::new("SchemaData")))?)
     }
 
     fn write_simple_array_data(
@@ -622,33 +598,33 @@ where
     ) -> Result<(), Error> {
         let filter_attrs = HashMap::from([("name".to_string(), simple_array_data.name.clone())]);
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"SimpleArrayData".to_vec()).with_attributes(
+            BytesStart::new("SimpleArrayData").with_attributes(
                 self.hash_map_as_attrs_filtered(&simple_array_data.attrs, &filter_attrs),
             ),
         ))?;
 
         for value in simple_array_data.values.iter() {
-            self.write_text_element(b"value", value)?;
+            self.write_text_element("value", value)?;
         }
 
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"SimpleArrayData")))?)
+            .write_event(Event::End(BytesEnd::new("SimpleArrayData")))?)
     }
 
     fn write_simple_data(&mut self, simple_data: &SimpleData) -> Result<(), Error> {
         let filter_attrs = HashMap::from([("name".to_string(), simple_data.name.clone())]);
-        self.writer.write_event(Event::Start(
-            BytesStart::owned_name(b"SimpleData".to_vec()).with_attributes(
+        self.writer
+            .write_event(Event::Start(BytesStart::new("SimpleData").with_attributes(
                 self.hash_map_as_attrs_filtered(&simple_data.attrs, &filter_attrs),
-            ),
-        ))?;
+            )))?;
 
-        self.writer.write(simple_data.value.as_bytes())?;
+        self.writer
+            .write_event(Event::Text(BytesText::new(&simple_data.value)))?;
 
         Ok(self
             .writer
-            .write_event(Event::End(BytesEnd::borrowed(b"SimpleData")))?)
+            .write_event(Event::End(BytesEnd::new("SimpleData")))?)
     }
 
     fn write_geometry(&mut self, geometry: &Geometry<T>) -> Result<(), Error> {
@@ -663,12 +639,12 @@ where
     }
 
     fn write_geom_props(&mut self, props: GeomProps<T>) -> Result<(), Error> {
-        self.write_text_element(b"extrude", if props.extrude { "1" } else { "0" })?;
-        self.write_text_element(b"tessellate", if props.tessellate { "1" } else { "0" })?;
-        self.write_text_element(b"altitudeMode", &props.altitude_mode.to_string())?;
+        self.write_text_element("extrude", if props.extrude { "1" } else { "0" })?;
+        self.write_text_element("tessellate", if props.tessellate { "1" } else { "0" })?;
+        self.write_text_element("altitudeMode", &props.altitude_mode.to_string())?;
         if !props.coords.is_empty() {
             self.write_text_element(
-                b"coordinates",
+                "coordinates",
                 &props
                     .coords
                     .iter()
@@ -682,30 +658,26 @@ where
 
     fn write_container(
         &mut self,
-        tag: &[u8],
+        tag: &str,
         attrs: &HashMap<String, String>,
         elements: &[Kml<T>],
     ) -> Result<(), Error> {
         self.writer.write_event(Event::Start(
-            BytesStart::owned_name(tag).with_attributes(self.hash_map_as_attrs(attrs)),
+            BytesStart::new(tag).with_attributes(self.hash_map_as_attrs(attrs)),
         ))?;
         for e in elements.iter() {
             self.write_kml(e)?;
         }
         // Wrapping in Ok to coerce the quick_xml::Error type with ?
-        Ok(self
-            .writer
-            .write_event(Event::End(BytesEnd::borrowed(tag)))?)
+        Ok(self.writer.write_event(Event::End(BytesEnd::new(tag)))?)
     }
 
-    fn write_text_element(&mut self, tag: &[u8], content: &str) -> Result<(), Error> {
+    fn write_text_element(&mut self, tag: &str, content: &str) -> Result<(), Error> {
         self.writer
-            .write_event(Event::Start(BytesStart::owned_name(tag)))?;
+            .write_event(Event::Start(BytesStart::new(tag)))?;
         self.writer
-            .write_event(Event::Text(BytesText::from_plain_str(content)))?;
-        Ok(self
-            .writer
-            .write_event(Event::End(BytesEnd::borrowed(tag)))?)
+            .write_event(Event::Text(BytesText::new(content)))?;
+        Ok(self.writer.write_event(Event::End(BytesEnd::new(tag)))?)
     }
 
     fn hash_map_as_attrs(&self, hash_map: &'a HashMap<String, String>) -> Vec<(&'a str, &'a str)> {


### PR DESCRIPTION
I went over and updated `quick-xml` dependency. Should fix issue #46 . There are also few clippy warnings, though they are regarding `#[default]` usage, which was stabilised quite recently, so I omited these.

Results of local benchmarks:
### Main
```
Benchmarking parse (countries.kml): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.2s, enable flat sampling, or reduce sample count to 50.
parse (countries.kml)   time:   [1.8128 ms 1.8155 ms 1.8181 ms]                                   
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

parse (sample.kml)      time:   [200.94 µs 201.19 µs 201.43 µs]                               
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
```

### Updated dependencies:
```
Benchmarking parse (countries.kml): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.7s, enable flat sampling, or reduce sample count to 50.
parse (countries.kml)   time:   [1.7568 ms 1.7585 ms 1.7603 ms]
                        change: [-3.2529% -3.0962% -2.9302%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

parse (sample.kml)      time:   [184.79 µs 185.04 µs 185.30 µs]
                        change: [-8.2117% -8.0063% -7.8325%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Ran on ryzen 5950x and 64 gigs of 3200 MT/s ram. Updated dependencies were consistently outperforming main branch.

I'd make sure that there are no issues / missed changes. Tests pass, and I tried to go through every change, but they were rather automatic so something might've slipped.