### PR TITLE
Fix default impl on enums

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,6 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[allow(clippy::derivable_impls)]
 pub mod types;
 
 pub use crate::types::{Kml, KmlDocument, KmlVersion};

--- a/src/types/altitude_mode.rs
+++ b/src/types/altitude_mode.rs
@@ -5,17 +5,12 @@ use crate::errors::Error;
 
 /// `kml:altitudeMode`, [9.20](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#322) in the
 /// KML specification
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum AltitudeMode {
+    #[default]
     ClampToGround,
     RelativeToGround,
     Absolute,
-}
-
-impl Default for AltitudeMode {
-    fn default() -> AltitudeMode {
-        AltitudeMode::ClampToGround
-    }
 }
 
 impl FromStr for AltitudeMode {

--- a/src/types/kml.rs
+++ b/src/types/kml.rs
@@ -13,18 +13,13 @@ use crate::types::{
 ///
 /// According to <http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#7> namespace for 2.3
 /// is unchanged since it should be backwards-compatible
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum KmlVersion {
+    #[default]
     Unknown,
     V22,
     V23,
-}
-
-impl Default for KmlVersion {
-    fn default() -> KmlVersion {
-        KmlVersion::Unknown
-    }
 }
 
 // TODO: According to http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#7 namespace for 2.3

--- a/src/types/link.rs
+++ b/src/types/link.rs
@@ -65,17 +65,12 @@ impl Default for Icon {
 }
 
 /// `kml:refreshModeEnumType`, [16.21](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#1239) in the KML specification.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum RefreshMode {
+    #[default]
     OnChange,
     OnInterval,
     OnExpire,
-}
-
-impl Default for RefreshMode {
-    fn default() -> RefreshMode {
-        RefreshMode::OnChange
-    }
 }
 
 impl FromStr for RefreshMode {
@@ -102,18 +97,13 @@ impl fmt::Display for RefreshMode {
 }
 
 /// `kml:viewRefreshModeEnumType`, [16.27](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html#1270) in the KML specification.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum ViewRefreshMode {
+    #[default]
     Never,
     OnRequest,
     OnStop,
     OnRegion,
-}
-
-impl Default for ViewRefreshMode {
-    fn default() -> ViewRefreshMode {
-        ViewRefreshMode::Never
-    }
 }
 
 impl FromStr for ViewRefreshMode {

--- a/src/types/style.rs
+++ b/src/types/style.rs
@@ -65,16 +65,11 @@ impl Default for BalloonStyle {
 
 /// `kml:colorMode`, [12.11](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#879) in the
 /// KML specification
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum ColorMode {
+    #[default]
     Default,
     Random,
-}
-
-impl Default for ColorMode {
-    fn default() -> ColorMode {
-        ColorMode::Default
-    }
 }
 
 impl FromStr for ColorMode {
@@ -214,18 +209,13 @@ impl Default for PolyStyle {
 
 /// `kml:listItemType`, [12.18](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#955) in the
 /// KML specification.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum ListItemType {
+    #[default]
     Check,
     CheckOffOnly,
     CheckHideChildren,
     RadioFolder,
-}
-
-impl Default for ListItemType {
-    fn default() -> ListItemType {
-        ListItemType::Check
-    }
 }
 
 impl FromStr for ListItemType {


### PR DESCRIPTION
Removes temporary `#[allow(clippy::derivable_impls)]` and implements defaults on enum through 1.62+ rust `derive`.