### PR TITLE
Fixed parsing of IconStyle hotSpot.

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -557,7 +557,7 @@ where
                     match e.local_name().as_ref() {
                         b"scale" => icon_style.scale = self.read_float()?,
                         b"heading" => icon_style.heading = self.read_float()?,
-                        b"hot_spot" => {
+                        b"hotSpot" => {
                             let x_val = attrs.get("x");
                             let y_val = attrs.get("y");
                             let xunits = attrs.get("xunits");


### PR DESCRIPTION
Hi,

this is just a quick fix for the IconStyle hotSpot parsing.
Was implemented as "hot_spot" but should be "hotSpot" according to https://developers.google.com/kml/documentation/kmlreference
I have tested the fix locally and the hotSpot is now correctly parsed.
Would be great if this could be included in the repo.

Cheers,
Adrian
