### PR TITLE
fix: allow cumulative innerBoundaryIs tags on a polygon

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -353,7 +353,10 @@ where
                         }
                         outer = outer_ring.remove(0);
                     }
-                    b"innerBoundaryIs" => inner = self.read_boundary(b"innerBoundaryIs")?,
+                    b"innerBoundaryIs" => {
+                        let mut boundary = self.read_boundary(b"innerBoundaryIs")?;
+                        inner.append(&mut boundary);
+                    }
                     b"altitudeMode" => {
                         altitude_mode = types::AltitudeMode::from_str(&self.read_str()?)?
                     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -354,8 +354,7 @@ where
                         outer = outer_ring.remove(0);
                     }
                     b"innerBoundaryIs" => {
-                        let mut boundary = self.read_boundary(b"innerBoundaryIs")?;
-                        inner.append(&mut boundary);
+                        inner.append(&mut self.read_boundary(b"innerBoundaryIs")?);
                     }
                     b"altitudeMode" => {
                         altitude_mode = types::AltitudeMode::from_str(&self.read_str()?)?


### PR DESCRIPTION
According to the Google KML docs, a Polygon is allowed to have "0 or more inner boundaries".
[Source](https://developers.google.com/kml/documentation/kmlreference#polygon)

In the current parser, the LinearRings within an `innerBoundaryIs` tags are assigned to the `inner` field of a parsed Polygon. However, if multiple `innerBoundaryIs` tags are present, only the last is currently assigned to the `inner` field of the Polygon. The proposed change appends output from `innerBoundaryIs` tags so that consecutive tags don't overwrite each other.

I created a small reproduction of this issue in a separate repo:

- Crate: https://github.com/cfzimmerman/kml_inner_boundary_repro/tree/main
- Here's an example of a file with data loss: https://github.com/cfzimmerman/kml_inner_boundary_repro/blob/main/inner_boundaries.kml
- And the two `.txt` files show the output difference between the current library and the changes in this branch.

Aside:
This is my first open source contribution. If I'm missing anything, please let me know! I appreciate everyone's work on this library and am grateful for the opportunity to give back.
