### PR TITLE
Add styleUrl to Placemark.

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -423,6 +423,7 @@ where
         let mut description: Option<String> = None;
         let mut geometry: Option<Geometry<T>> = None;
         let mut children: Vec<Element> = Vec::new();
+        let mut style_url: Option<String> = None;
 
         loop {
             let e = self.reader.read_event_into(&mut self.buf)?;
@@ -432,6 +433,7 @@ where
                     match e.local_name().as_ref() {
                         b"name" => name = Some(self.read_str()?),
                         b"description" => description = Some(self.read_str()?),
+                        b"styleUrl" => style_url = Some(self.read_str()?),
                         b"Point" => geometry = Some(Geometry::Point(self.read_point(attrs)?)),
                         b"LineString" => {
                             geometry = Some(Geometry::LineString(self.read_line_string(attrs)?))
@@ -462,6 +464,7 @@ where
         Ok(Placemark {
             name,
             description,
+            style_url,
             geometry,
             attrs,
             children,
@@ -1599,6 +1602,7 @@ mod tests {
             <Placemark>
             <name><![CDATA[Test & Test]]></name>
             <description>1¼ miles</description>
+            <styleUrl>#foo</styleUrl>
             <Point>
             <coordinates>
                 -1.0,1.0,0
@@ -1614,6 +1618,7 @@ mod tests {
         .unwrap();
         assert_eq!(placemark.name, Some("Test & Test".to_string()));
         assert_eq!(placemark.description, Some("1¼ miles".to_string()));
+        assert_eq!(placemark.style_url, Some("#foo".to_string()));
     }
 
     #[test]

--- a/src/types/placemark.rs
+++ b/src/types/placemark.rs
@@ -16,6 +16,7 @@ pub struct Placemark<T: CoordType = f64> {
     pub name: Option<String>,
     pub description: Option<String>,
     pub geometry: Option<Geometry<T>>,
+    pub style_url: Option<String>,
     pub attrs: HashMap<String, String>,
     pub children: Vec<Element>,
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -250,6 +250,9 @@ where
         if let Some(geometry) = &placemark.geometry {
             self.write_geometry(geometry)?;
         }
+        if let Some(style_url) = &placemark.style_url {
+            self.write_text_element("styleUrl", style_url)?;
+        }
         Ok(self
             .writer
             .write_event(Event::End(BytesEnd::new("Placemark")))?)


### PR DESCRIPTION
Google Earth does add `styleUrl` to Placemark but it wasn't supported.  Fix it.