### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["geo", "geospatial", "kml"]
 exclude = [".github/*"]
 
 [dependencies]
-quick-xml = "0.31"
+quick-xml = "0.37.1"
 num-traits = "0.2"
 thiserror = "1.0"
 geo-types = { version = ">=0.6, <0.8", optional = true }
-zip = { version = "0.6", optional = true, default-features = false, features = [
+zip = { version = "2.2", optional = true, default-features = false, features = [
     "bzip2",
     "deflate",
     "time",

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -85,8 +85,8 @@ where
     }
 
     fn from_xml_reader(mut reader: quick_xml::Reader<B>) -> KmlReader<B, T> {
-        reader.trim_text(true);
-        reader.expand_empty_elements(true);
+        let config = reader.config_mut();
+        config.trim_text(true);
         KmlReader {
             reader,
             buf: Vec::new(),


### PR DESCRIPTION
A few dependency versions are pretty old, updating them here and including full versions to align with Rust standards.

The call to `expand_empty_elements` can be removed here because as of [version 0.3.1 in quick-xml](https://github.com/tafia/quick-xml/blob/master/Changelog.md#031) it was made the default