### PR TITLE
Deprecate quick collection for TryFrom

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ writer.write(&kml).unwrap();
 
 ```rust
 use geo_types::{self, GeometryCollection};
-use kml::{quick_collection, Kml, types::Point};
+use kml::{Kml, types::Point};
 
 let kml_point = Point::new(1., 1., None);
 // Convert into geo_types primitives
@@ -87,8 +87,7 @@ let kml_folder_str = r#"
 </Folder>"#;
 let kml_folder: Kml<f64> = kml_folder_str.parse().unwrap();
 
-// Use the quick_collection helper to convert Kml to a geo_types::GeometryCollection
-let geom_coll: GeometryCollection<f64> = quick_collection(kml_folder).unwrap();
+let geom_coll: GeometryCollection<f64> = kml_folder.try_into().unwrap();
 ```
 
 ## Code of Conduct

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -425,7 +425,7 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    fn test_quick_collection() {
+    fn test_try_from_collection() {
         let k = KmlDocument {
             elements: vec![
                 Kml::Point(Point::from(Coord::from((1., 1.)))),
@@ -448,6 +448,9 @@ mod tests {
             geo_types::Geometry::LineString(geo_types::LineString::from(vec![(1., 1.), (2., 2.)])),
             geo_types::Geometry::Point(geo_types::Point::from((3., 3.))),
         ]);
-        assert_eq!(quick_collection(Kml::KmlDocument(k)).unwrap(), gc);
+        assert_eq!(
+            geo_types::GeometryCollection::try_from(Kml::KmlDocument(k)).unwrap(),
+            gc
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //! ```
 //! # #[cfg(feature = "geo-types")] {
 //! use geo_types::{self, GeometryCollection};
-//! use kml::{quick_collection, Kml, types::Point};
+//! use kml::{Kml, types::Point};
 //!
 //! let kml_point = Point::new(1., 1., None);
 //! // Convert into geo_types primitives
@@ -88,8 +88,7 @@
 //! </Folder>"#;
 //! let kml_folder: Kml<f64> = kml_folder_str.parse().unwrap();
 //!
-//! // Use the quick_collection helper to convert Kml to a geo_types::GeometryCollection
-//! let geom_coll: GeometryCollection<f64> = quick_collection(kml_folder).unwrap();
+//! let geom_coll: GeometryCollection<f64> = kml_folder.try_into().unwrap();
 //! # }
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ pub use crate::writer::KmlWriter;
 pub mod conversion;
 
 #[cfg(feature = "geo-types")]
+#[allow(deprecated)]
 pub use conversion::quick_collection;
 
 #[cfg(feature = "zip")]


### PR DESCRIPTION
Following what was done in [geojson](https://github.com/georust/geojson/blob/main/CHANGES.md#unreleased) and replacing the separate `quick_collection` method with an implementation of `TryFrom` for `geo_types::GeometryCollection`