### PR TITLE
Add name, description, and styleUrl support for Folder

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -358,7 +358,8 @@ where
                 .flat_map(Vec::<geo_types::Geometry<T>>::try_from)
                 .flatten()
                 .collect()),
-            Kml::Folder { elements, .. } => Ok(elements
+            Kml::Folder(f) => Ok(f
+                .elements
                 .into_iter()
                 .flat_map(Vec::<geo_types::Geometry<T>>::try_from)
                 .flatten()
@@ -421,16 +422,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::Folder;
     use crate::KmlDocument;
-    use std::collections::HashMap;
 
     #[test]
     fn test_try_from_collection() {
         let k = KmlDocument {
             elements: vec![
                 Kml::Point(Point::from(Coord::from((1., 1.)))),
-                Kml::Folder {
-                    attrs: HashMap::new(),
+                Kml::Folder(Folder {
                     elements: vec![
                         Kml::LineString(LineString::from(vec![
                             Coord::from((1., 1.)),
@@ -438,7 +438,8 @@ mod tests {
                         ])),
                         Kml::Point(Point::from(Coord::from((3., 3.)))),
                     ],
-                },
+                    ..Default::default()
+                }),
             ],
             ..Default::default()
         };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -472,6 +472,7 @@ where
         let mut name = None;
         let mut description = None;
         let mut folder_elements = Vec::new();
+        let mut style_url: Option<String> = None;
 
         loop {
             let mut e = self.reader.read_event_into(&mut self.buf)?;
@@ -481,6 +482,7 @@ where
                     match e.local_name().as_ref() {
                         b"name" => name = Some(self.read_str()?),
                         b"description" => description = Some(self.read_str()?),
+                        b"styleUrl" => style_url = Some(self.read_str()?),
                         _ => {
                             let start = e.to_owned();
                             let element = self.read_element(&start, attrs)?;
@@ -501,6 +503,7 @@ where
         Ok(Folder {
             name,
             description,
+            style_url,
             attrs,
             elements: folder_elements,
         })
@@ -1661,9 +1664,11 @@ mod tests {
         let kml_str = r#"
     <Folder>
         <name>Folder 1</name>
+        <description>Folder 1 description</description>
     </Folder>
     <Folder>
         <name>Folder 2</name>
+        <description>Folder 2 description</description>
     </Folder>
     "#;
         let f: Kml = kml_str.parse().unwrap();
@@ -1680,7 +1685,8 @@ mod tests {
             e,
             Kml::Folder(Folder {
                 name: Some(_),
-                description: None,
+                description: Some(_),
+                style_url: None,
                 attrs: _,
                 elements: _,
             })
@@ -1695,9 +1701,11 @@ mod tests {
     <Document>
     <Folder>
         <name>Folder 1</name>
+        <styleUrl>#foo</styleUrl>
     </Folder>
     <Folder>
         <name>Folder 2</name>
+        <styleUrl>#foo</styleUrl>
     </Folder>
     </Document>
     </kml>
@@ -1720,6 +1728,7 @@ mod tests {
             Kml::Folder(Folder {
                 name: Some(_),
                 description: None,
+                style_url: Some(_),
                 attrs: _,
                 elements: _,
             })

--- a/src/types/folder.rs
+++ b/src/types/folder.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 pub struct Folder<T: CoordType = f64> {
     pub name: Option<String>,
     pub description: Option<String>,
+    pub style_url: Option<String>,
     pub attrs: HashMap<String, String>,
     pub elements: Vec<Kml<T>>,
 }

--- a/src/types/folder.rs
+++ b/src/types/folder.rs
@@ -1,0 +1,14 @@
+use crate::types::{CoordType, Kml};
+use std::collections::HashMap;
+
+/// `kml:Folder`, [9.13](http://docs.opengeospatial.org/is/12-007r2/12-007r2.html#241) in the KML
+/// specification
+///
+/// Partially implemented.
+#[derive(Clone, Default, PartialEq, Debug)]
+pub struct Folder<T: CoordType = f64> {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub attrs: HashMap<String, String>,
+    pub elements: Vec<Kml<T>>,
+}

--- a/src/types/kml.rs
+++ b/src/types/kml.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 
 use crate::errors::Error;
 use crate::types::{
-    Alias, BalloonStyle, CoordType, Element, Icon, IconStyle, LabelStyle, LineString, LineStyle,
-    LinearRing, Link, LinkTypeIcon, ListStyle, Location, MultiGeometry, Orientation, Pair,
-    Placemark, Point, PolyStyle, Polygon, ResourceMap, Scale, SchemaData, SimpleArrayData,
+    Alias, BalloonStyle, CoordType, Element, Folder, Icon, IconStyle, LabelStyle, LineString,
+    LineStyle, LinearRing, Link, LinkTypeIcon, ListStyle, Location, MultiGeometry, Orientation,
+    Pair, Placemark, Point, PolyStyle, Polygon, ResourceMap, Scale, SchemaData, SimpleArrayData,
     SimpleData, Style, StyleMap,
 };
 
@@ -64,10 +64,7 @@ pub enum Kml<T: CoordType = f64> {
         attrs: HashMap<String, String>,
         elements: Vec<Kml<T>>,
     },
-    Folder {
-        attrs: HashMap<String, String>,
-        elements: Vec<Kml<T>>,
-    },
+    Folder(Folder<T>),
     Style(Style),
     StyleMap(StyleMap),
     Pair(Pair),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -29,6 +29,9 @@ mod element;
 pub(crate) mod geom_props;
 mod placemark;
 
+mod folder;
+pub use folder::Folder;
+
 pub use element::Element;
 pub use placemark::Placemark;
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -282,6 +282,9 @@ where
         if let Some(description) = &folder.description {
             self.write_text_element("description", description)?;
         }
+        if let Some(style_url) = &folder.style_url {
+            self.write_text_element("styleUrl", style_url)?;
+        }
         for e in folder.elements.iter() {
             self.write_kml(e)?;
         }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

Added support for a nam, description, and styleUrl, and cleaned it up into a new `Folder` type. The new type does not fully implement the entire structure defined by ogc, https://docs.ogc.org/is/12-007r2/12-007r2.html#241