### PR TITLE
Don't fail parsing on empty coordinates

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1762,23 +1762,19 @@ mod tests {
     #[test]
     fn test_parse_empty_coordinates() {
         let kml_str = r#"
-            <?xml version="1.0" encoding="utf-8"?>
-            <kml xmlns="http://www.opengis.net/kml/2.2">
-              <Document>
-                <Placemark>
-                  <name>test</name>
-                  <LineString>
-                    <altitudeMode>absolute</altitudeMode>
-                    <coordinates />
-                  </LineString>
-                </Placemark>
-              </Document>
-            </kml>
+        <LineString>
+            <altitudeMode>absolute</altitudeMode>
+            <coordinates />
+        </LineString>
         "#;
 
-        assert!(matches!(
+        assert_eq!(
             Kml::<f64>::from_str(kml_str).unwrap(),
-            Kml::KmlDocument(_)
-        ));
+            Kml::LineString(LineString {
+                coords: vec![],
+                altitude_mode: types::AltitudeMode::Absolute,
+                ..Default::default()
+            })
+        );
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1134,18 +1134,13 @@ where
                 _ => {}
             }
         }
-        if coords.is_empty() {
-            Err(Error::InvalidGeometry(
-                "Geometry must contain coordinates element".to_string(),
-            ))
-        } else {
-            Ok(GeomProps {
-                coords,
-                altitude_mode,
-                extrude,
-                tessellate,
-            })
-        }
+
+        Ok(GeomProps {
+            coords,
+            altitude_mode,
+            extrude,
+            tessellate,
+        })
     }
 
     fn read_float<F: Float + FromStr>(&mut self) -> Result<F, Error> {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1758,4 +1758,27 @@ mod tests {
             Kml::KmlDocument(_)
         ));
     }
+
+    #[test]
+    fn test_parse_empty_coordinates() {
+        let kml_str = r#"
+            <?xml version="1.0" encoding="utf-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+              <Document>
+                <Placemark>
+                  <name>test</name>
+                  <LineString>
+                    <altitudeMode>absolute</altitudeMode>
+                    <coordinates />
+                  </LineString>
+                </Placemark>
+              </Document>
+            </kml>
+        "#;
+
+        assert!(matches!(
+            Kml::<f64>::from_str(kml_str).unwrap(),
+            Kml::KmlDocument(_)
+        ));
+    }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

This change allows the parsing of `kml` files with empty `coordinates` (this can be checked on client code):

```xml
<?xml version="1.0" encoding="utf-8"?>
<kml xmlns="http://www.opengis.net/kml/2.2">
  <Document>
    <Placemark>
      <name>test</name>
      <LineString>
        <altitudeMode>absolute</altitudeMode>
        <coordinates />
      </LineString>
    </Placemark>
  </Document>
</kml>
```

I have customers provided `kml` files with some valid `Placemark` and some invalid (empty coordinates like in the example). 
Right now I cannot parse the file because it return an error for empty `coordinates` but this can be safely checked inside client code.
