### PR TITLE
KmlDocument's version and attributes handling

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1698,6 +1698,87 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_kml_document_version() {
+        let xmlns = "xmlns".to_string();
+        let xmlns_kml = "xmlns:kml".to_string();
+        let xmlns_v2_2 = "http://www.opengis.net/kml/2.2".to_string();
+        let xmlns_v2_3 = "http://www.opengis.net/kml/2.3".to_string();
+        let kml_str_v2_2 = format!(
+            r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <kml {xmlns}="{xmlns_v2_2}">
+        </kml>
+        "#
+        );
+        let kml_str_v2_3 = format!(
+            r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <kml {xmlns}="{xmlns_v2_3}">
+        </kml>
+        "#
+        );
+        let kml_str_v2_2_xmlns_kml = format!(
+            r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <kml {xmlns_kml}="{xmlns_v2_2}">
+        </kml>
+        "#
+        );
+        let kml_str_v2_3_xmlns_kml = format!(
+            r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <kml {xmlns_kml}="{xmlns_v2_3}">
+        </kml>
+        "#
+        );
+        let kml_str_v_unknown = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <kml>
+        </kml>
+        "#;
+
+        assert_eq!(
+            Kml::<f64>::from_str(&kml_str_v2_2).unwrap(),
+            Kml::KmlDocument(KmlDocument {
+                version: KmlVersion::V22,
+                attrs: HashMap::from([(xmlns.clone(), xmlns_v2_2.clone())]),
+                ..Default::default()
+            })
+        );
+        assert_eq!(
+            Kml::<f64>::from_str(&kml_str_v2_3).unwrap(),
+            Kml::KmlDocument(KmlDocument {
+                version: KmlVersion::V23,
+                attrs: HashMap::from([(xmlns, xmlns_v2_3.clone())]),
+                ..Default::default()
+            })
+        );
+        assert_eq!(
+            Kml::<f64>::from_str(&kml_str_v2_2_xmlns_kml).unwrap(),
+            Kml::KmlDocument(KmlDocument {
+                version: KmlVersion::V22,
+                attrs: HashMap::from([(xmlns_kml.clone(), xmlns_v2_2)]),
+                ..Default::default()
+            })
+        );
+        assert_eq!(
+            Kml::<f64>::from_str(&kml_str_v2_3_xmlns_kml).unwrap(),
+            Kml::KmlDocument(KmlDocument {
+                version: KmlVersion::V23,
+                attrs: HashMap::from([(xmlns_kml, xmlns_v2_3)]),
+                ..Default::default()
+            })
+        );
+        assert_eq!(
+            Kml::<f64>::from_str(kml_str_v_unknown).unwrap(),
+            Kml::KmlDocument(KmlDocument {
+                version: KmlVersion::Unknown,
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
     fn test_read_str_lossy() {
         let kml_str = r#"
             <Placemark>

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -200,15 +200,18 @@ where
         Ok(elements)
     }
 
-    fn read_kml_document(&mut self, attrs: HashMap<String, String>) -> Result<KmlDocument<T>, Error> {
+    fn read_kml_document(
+        &mut self,
+        attrs: HashMap<String, String>,
+    ) -> Result<KmlDocument<T>, Error> {
         let version = match attrs.get("xmlns").or_else(|| attrs.get("xmlns:kml")) {
             Some(xmlns) => KmlVersion::from_str(xmlns).unwrap_or_default(),
-            None => KmlVersion::default()
+            None => KmlVersion::default(),
         };
         Ok(KmlDocument {
             version,
             attrs,
-            elements: self.read_elements()?
+            elements: self.read_elements()?,
         })
     }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
Today i tried to use this library and notice that i cannot get document version, so I suggest these changes to fix it. I also provide the attributes to the document for passing the tests